### PR TITLE
Fix GherkinCodeStyleSettingsProvider deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GherkinCodeStyleSettingsProvider deprecation warning by overriding getLanguage().
+- Updated platformVersion to 253.30387.90 (IntelliJ 2025.3.2).
+
 ## [2.4.12] - 2025-12-15
 
 ### Modified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ Key version properties are in `gradle.properties`:
 
 Dependency versions are managed in `gradle/libs.versions.toml`.
 
+**When updating `platformVersion`:** Always run `./gradlew verifyPlugin test` to ensure plugin compatibility and tests pass against the new platform version.
+
 ## Project Structure
 
 ```
@@ -254,6 +256,10 @@ Key dependencies (see `gradle/libs.versions.toml` and `gradle.properties`):
 | Mockito | 5.19.0 | Mocking |
 | GrammarKit | 2022.3.2.2 | Lexer/parser generation |
 | Kotlin | 2.2.10 | Kotlin support |
+
+## Changelog
+
+Update `CHANGELOG.md` for every major change. Add entries under the `## [Unreleased]` section using [Keep a Changelog](https://keepachangelog.com) format (`### Added`, `### Fixed`, `### Modified`, etc.). The CI deploy action handles version bumping and release — do not manually create version entries.
 
 ## Common Tasks
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
-platformVersion = 253.28294.334
+platformVersion = 253.30387.90
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/rankweis/uppercut/karate/psi/formatter/GherkinCodeStyleSettingsProvider.java
+++ b/src/main/kotlin/com/rankweis/uppercut/karate/psi/formatter/GherkinCodeStyleSettingsProvider.java
@@ -2,13 +2,21 @@ package com.rankweis.uppercut.karate.psi.formatter;
 
 import com.intellij.application.options.CodeStyleAbstractConfigurable;
 import com.intellij.application.options.CodeStyleAbstractPanel;
+import com.intellij.lang.Language;
 import com.intellij.psi.codeStyle.CodeStyleConfigurable;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
 import com.rankweis.uppercut.karate.MyBundle;
+import com.rankweis.uppercut.karate.psi.KarateLanguage;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class GherkinCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
+
+  @Override
+  public @Nullable Language getLanguage() {
+    return KarateLanguage.INSTANCE;
+  }
   
   @NotNull
   @Override


### PR DESCRIPTION
## Summary
- Fix `GherkinCodeStyleSettingsProvider` deprecation warning by overriding `getLanguage()` to return `KarateLanguage.INSTANCE`
- Update `platformVersion` to `253.30387.90` (IntelliJ 2025.3.2)
- Add changelog and platformVersion update rules to `CLAUDE.md`

## Test plan
- [x] `./gradlew compileJava compileKotlin` — passes
- [x] `./gradlew verifyPlugin` — plugin compatible with IU-253.30387.90
- [x] `./gradlew test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)