### PR TITLE
chore: CI/build cleanup - remove Kotlin, fix CodeQL, bump deps

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ pluginRepositoryUrl = https://github.com/rankweis/uppercut
 # SemVer format -> https://semver.org
 pluginVersion = 2.4.14
 karateVersion = 1.5.1
-logbackVersion = 1.5.6
+logbackVersion = 1.5.28
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 253


### PR DESCRIPTION
## Summary
- Remove Kotlin from main sources (convert 2 files to Java), remove Kotlin plugin/deps
- Replace Kover with JaCoCo for code coverage
- Move source directories from `src/*/kotlin` to `src/*/java`
- Fix CodeQL workflow (Kotlin 2.3.10 was too new for CodeQL's extractor)
- Update IntelliJ Gradle Plugin to 2.10.5, fix `idea.home.path` for tests
- Add custom CodeQL workflow with manual build steps
- Clean up Gradle config (repos, unused deps, logging)
- Bump logback 1.5.6 → 1.5.28 (fixes 4 dependabot security alerts)

## Test plan
- [x] All CI checks pass (Build, Test, CodeQL, Verify)
- [x] 242 files detected as 100% renames by git
- [x] logback-core vulnerabilities resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)