### PR TITLE
Fix working directory resolution and duplicate HTTP logs (#284, #276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed run configurations using the project root as working directory instead of the module root in multi-module projects, causing Karate `file:` reads to fail. (#284)
+- Fixed gutter-button-generated run configurations ignoring the Run Configuration template's working directory setting. (#284)
+- Fixed HTTP request/response logs appearing duplicated in the Test Result tree when using DEBUG-level logging. (#276)
+
 ## [2.4.16] - 2026-02-27
 
 ### Fixed

--- a/KarateTestRunner/src/main/java/com/rankweis/uppercut/testrunner/KarateTestRunner.java
+++ b/KarateTestRunner/src/main/java/com/rankweis/uppercut/testrunner/KarateTestRunner.java
@@ -4,7 +4,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
 import com.intuit.karate.core.FeatureRuntime;
 import com.intuit.karate.core.ScenarioCall;
@@ -223,15 +222,15 @@ public class KarateTestRunner {
     outputStreamAppender.setName("KarateAppender");
     outputStreamAppender.setEncoder(encoder);
     outputStreamAppender.start();
-    List<Appender<ILoggingEvent>> appenders = new ArrayList<>();
-
     Logger intuitLogger = context.getLogger(Logger.ROOT_LOGGER_NAME);
+    List<ConsoleAppender<ILoggingEvent>> consoleAppenders = new ArrayList<>();
     intuitLogger.iteratorForAppenders().forEachRemaining(appender -> {
-      appenders.add(appender);
-      intuitLogger.detachAppender(appender);
+      if (appender instanceof ConsoleAppender) {
+        consoleAppenders.add((ConsoleAppender<ILoggingEvent>) appender);
+      }
     });
+    consoleAppenders.forEach(intuitLogger::detachAppender);
     intuitLogger.addAppender(outputStreamAppender);
-    appenders.forEach(intuitLogger::addAppender);
   }
 
 }

--- a/src/main/java/com/rankweis/uppercut/karate/run/KarateOutputToGeneralTestEventsConverter.java
+++ b/src/main/java/com/rankweis/uppercut/karate/run/KarateOutputToGeneralTestEventsConverter.java
@@ -52,12 +52,12 @@ public class KarateOutputToGeneralTestEventsConverter extends OutputToGeneralTes
   private final Map<String, LinkedList<KarateItem>> threadToScenarioStack = new HashMap<>();
   private final Map<Integer, KarateItem> idToItem = new HashMap<>();
   private String currentThreadGroup = "main";
-  public static final String UPPERCUT_LOG = "^<<UPPERCUT>>";
+  private static final String UPPERCUT_PREFIX = "<<UPPERCUT>>";
   public static final Pattern UPPERCUT_LOG_PATTERN =
-    Pattern.compile(UPPERCUT_LOG + "\\[([^]]+)] ([\\d:.,]+) (\\w+) ?(.*)\n?");
+    Pattern.compile("^\\[([^]]+)] ([\\d:.,]+) (\\w+) ?(.*)\n?");
   public static final Pattern SCENARIO_NAME =
-    Pattern.compile(UPPERCUT_LOG
-      + "\\[([^]]*)].* Scenario name: (.*), featureFileName: (.*), id (\\d+), featureId (\\d+), (.*) <<UPPERCUT>>\n?$");
+    Pattern.compile(
+      "^\\[([^]]*)].* Scenario name: (.*), featureFileName: (.*), id (\\d+), featureId (\\d+), (.*) <<UPPERCUT>>\n?$");
   public static final Pattern FEATURE_FILE_NAME =
     Pattern.compile(".*KarateTestRunner - FeatureFileName: ([^,]*), id: (\\d+), (.*) <<UPPERCUT>>\n?");
   private static final Pattern FEATURE_LINE_PATTERN = Pattern.compile("feature: \\S+\n?");
@@ -80,6 +80,9 @@ public class KarateOutputToGeneralTestEventsConverter extends OutputToGeneralTes
 
   @Override public void process(String text, Key outputType) {
     if (text != null) {
+      if (text.startsWith(UPPERCUT_PREFIX)) {
+        text = text.substring(UPPERCUT_PREFIX.length());
+      }
       Matcher matcher = UPPERCUT_LOG_PATTERN.matcher(text);
       if (matcher.matches()) {
         String logLevel = matcher.group(3);
@@ -98,8 +101,8 @@ public class KarateOutputToGeneralTestEventsConverter extends OutputToGeneralTes
   private boolean process(String text) {
     LinkedList<KarateItem> karateItems =
       threadToScenarioStack.computeIfAbsent(currentThreadGroup, k -> new LinkedList<>());
-    if (text.startsWith("<<UPPERCUT>>") || text.strip().endsWith("<<UPPERCUT>>")) {
-      // Safety guard, should never hit this.
+    if (text.strip().endsWith("<<UPPERCUT>>")) {
+      // Safety guard: consume structural messages that shouldn't be shown to user.
       return true;
     }
     if (!karateItems.isEmpty()) {
@@ -154,7 +157,11 @@ public class KarateOutputToGeneralTestEventsConverter extends OutputToGeneralTes
     if (featureStartEnd(text) || scenarioStartEnd(text)) {
       return true;
     }
-    // Always consume anything with <<UPPERCUT>> so it will never be shown to user.
+    // Strip the UPPERCUT prefix and forward the log message content to scenario output.
+    String content = matcher.group(4);
+    if (content != null && !content.isEmpty()) {
+      return process(content + "\n");
+    }
     return true;
   }
 

--- a/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfigurationProducer.java
+++ b/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfigurationProducer.java
@@ -7,7 +7,6 @@ import com.intellij.execution.actions.LazyRunConfigurationProducer;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Ref;
@@ -25,7 +24,6 @@ import com.rankweis.uppercut.karate.psi.GherkinStepsHolder;
 import com.rankweis.uppercut.karate.psi.KarateTokenTypes;
 import com.rankweis.uppercut.karate.run.KarateRunConfiguration.PreferredTest;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
@@ -101,12 +99,18 @@ public class KarateRunConfigurationProducer extends LazyRunConfigurationProducer
   protected boolean setupConfigurationFromContext(@NotNull KarateRunConfiguration configuration,
     @NotNull ConfigurationContext context,
     @NotNull Ref<PsiElement> sourceElement) {
-    String baseDir = FileUtil.toSystemIndependentName(StringUtil.notNullize(context.getProject().getBasePath()));
     final PsiElement location = context.getPsiLocation();
-    configuration.setWorkingDirectory(baseDir);
     Module contextModule = context.getModule();
     if (contextModule != null) {
       configuration.setModule(contextModule);
+    }
+    String moduleDir = getModuleContentRoot(contextModule);
+    if (moduleDir != null) {
+      configuration.setWorkingDirectory(moduleDir);
+    } else {
+      String baseDir = FileUtil.toSystemIndependentName(
+        StringUtil.notNullize(context.getProject().getBasePath()));
+      configuration.setWorkingDirectory(baseDir);
     }
     Optional<VirtualFile> virtualFile =
       Optional.of(context).map(ConfigurationContext::getLocation).map(Location::getVirtualFile);
@@ -136,10 +140,10 @@ public class KarateRunConfigurationProducer extends LazyRunConfigurationProducer
     IElementType elementType = PsiUtilCore.getElementType(psiElement);
     if (elementType == KarateTokenTypes.TAG) {
       preferredTest = PreferredTest.ALL_TAGS;
-      Arrays.stream(ModuleManager.getInstance(context.getProject()).getModules())
-        .flatMap(m -> Arrays.stream(ModuleRootManager.getInstance(m).getSourceRoots()))
-        .map(root -> (path != null && path.contains(root.getPath())) ? root : null).filter(Objects::nonNull).findFirst()
-        .ifPresent(vf -> configuration.setWorkingDirectory(vf.getPath()));
+      String tagModuleDir = getModuleContentRoot(contextModule);
+      if (tagModuleDir != null) {
+        configuration.setWorkingDirectory(tagModuleDir);
+      }
       configuration.setTag(psiElement.getText());
     } else {
       GherkinStepsHolder holder;
@@ -188,6 +192,17 @@ public class KarateRunConfigurationProducer extends LazyRunConfigurationProducer
     configuration.setPreferredTest(PreferredTest.ALL_IN_FOLDER);
     configuration.setName("Karate tests in '" + dir.getName() + "'");
     return true;
+  }
+
+  private static @Nullable String getModuleContentRoot(@Nullable Module module) {
+    if (module == null) {
+      return null;
+    }
+    VirtualFile[] contentRoots = ModuleRootManager.getInstance(module).getContentRoots();
+    if (contentRoots.length > 0) {
+      return FileUtil.toSystemIndependentName(contentRoots[0].getPath());
+    }
+    return null;
   }
 
   private static String getRelativePathFromModule(Module contextModule, String path, String name) {


### PR DESCRIPTION
- Use module content root instead of project root for run configuration working directory in multi-module projects
- Remove duplicate console appender in KarateTestRunner that caused HTTP request/response logs to appear twice in Test Result tree
- Strip <<UPPERCUT>> prefix from output shown to users