### PR TITLE
Replace deprecated APIs for IntelliJ 2026.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 .intellijPlatform
 .idea-sandbox
 /out/
+/.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ## [Unreleased]
 
-## [2.4.17] - 2026-03-07
+## [2.5.0] - 2026-03-07
 
 ### Fixed
 
 - Fixed run configurations using the project root as working directory instead of the module root in multi-module projects, causing Karate `file:` reads to fail. (#284)
 - Fixed gutter-button-generated run configurations ignoring the Run Configuration template's working directory setting. (#284)
 - Fixed HTTP request/response logs appearing duplicated in the Test Result tree when using DEBUG-level logging. (#276)
+- Replaced deprecated `ReadAction.compute(ThrowableComputable)` calls with `ApplicationManager.runReadAction(Computable)` for IntelliJ 2026.1 compatibility.
+- Removed deprecated `PositionManager.getAcceptedFileTypes()` override in `KaratePositionManager`.
 
 ## [2.4.16] - 2026-02-27
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.rankweis.uppercut
 pluginName = uppercut
 pluginRepositoryUrl = https://github.com/rankweis/uppercut
 # SemVer format -> https://semver.org
-pluginVersion = 2.4.18
+pluginVersion = 2.5.0
 karateVersion = 1.5.1
 logbackVersion = 1.5.28
 

--- a/src/main/java/com/rankweis/uppercut/karate/CucumberUtil.java
+++ b/src/main/java/com/rankweis/uppercut/karate/CucumberUtil.java
@@ -5,10 +5,11 @@ import com.rankweis.uppercut.karate.steps.AbstractStepDefinition;
 import com.rankweis.uppercut.karate.steps.search.CucumberStepSearchUtil;
 import com.rankweis.uppercut.karate.psi.GherkinStep;
 import com.rankweis.uppercut.karate.steps.reference.KarateStepReference;
-import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.StringUtil;
@@ -127,7 +128,8 @@ public final class CucumberUtil {
       return true;
     }
 
-    final SearchScope searchScope = ReadAction.compute(() -> CucumberStepSearchUtil.restrictScopeToGherkinFiles(effectiveSearchScope));
+    final SearchScope searchScope = ApplicationManager.getApplication()
+      .runReadAction((Computable<SearchScope>) () -> CucumberStepSearchUtil.restrictScopeToGherkinFiles(effectiveSearchScope));
 
 
     final short context = (short)(UsageSearchContext.IN_STRINGS | UsageSearchContext.IN_CODE);

--- a/src/main/java/com/rankweis/uppercut/karate/debugging/KaratePositionManager.java
+++ b/src/main/java/com/rankweis/uppercut/karate/debugging/KaratePositionManager.java
@@ -12,11 +12,8 @@ import com.intellij.debugger.engine.PositionManagerImpl.JavaSourcePosition;
 import com.intellij.debugger.impl.DebuggerUtilsEx;
 import com.intellij.debugger.requests.ClassPrepareRequestor;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.util.Computable;
-import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.psi.PsiElement;
-import com.rankweis.uppercut.karate.psi.GherkinFileType;
 import com.sun.jdi.AbsentInformationException;
 import com.sun.jdi.Location;
 import com.sun.jdi.ReferenceType;
@@ -112,7 +109,7 @@ public class KaratePositionManager implements PositionManager {
       List<Object> methodMatch =
         (List<Object>) match.invoke(stepRuntimeClass,
           ApplicationManager.getApplication().runReadAction(
-            (ThrowableComputable<String, RuntimeException>) () -> dealWithSteps(sourcePosition.getElementAt())));
+            (Computable<String>) () -> dealWithSteps(sourcePosition.getElementAt())));
 
       return methodMatch.stream().map(m -> {
         try {
@@ -234,10 +231,6 @@ public class KaratePositionManager implements PositionManager {
     ClassPrepareRequest classPrepareRequest1 = debugProcess.getRequestsManager()
       .createClassPrepareRequest(waitRequestor, position.getFile().getName() + "$*");
     return classPrepareRequest1;
-  }
-
-  @Override public @Nullable Set<? extends FileType> getAcceptedFileTypes() {
-    return Set.of(GherkinFileType.INSTANCE);
   }
 
 }

--- a/src/main/java/com/rankweis/uppercut/karate/inspections/suppress/GherkinSuppressionUtil.java
+++ b/src/main/java/com/rankweis/uppercut/karate/inspections/suppress/GherkinSuppressionUtil.java
@@ -5,7 +5,8 @@ import static com.intellij.codeInspection.SuppressionUtil.COMMON_SUPPRESS_REGEXP
 
 import com.intellij.codeInspection.SuppressQuickFix;
 import com.intellij.codeInspection.SuppressionUtil;
-import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.Computable;
 import com.intellij.psi.PsiComment;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -31,7 +32,8 @@ public final class GherkinSuppressionUtil {
   }
 
   public static boolean isSuppressedFor(@NotNull final PsiElement element, @NotNull final String toolId) {
-    return ReadAction.compute(() -> getSuppressedIn(element, toolId) != null).booleanValue();
+    return ApplicationManager.getApplication()
+      .runReadAction((Computable<Boolean>) () -> getSuppressedIn(element, toolId) != null);
   }
 
   @Nullable

--- a/src/main/java/com/rankweis/uppercut/karate/run/KarateOutputToGeneralTestEventsConverter.java
+++ b/src/main/java/com/rankweis/uppercut/karate/run/KarateOutputToGeneralTestEventsConverter.java
@@ -8,10 +8,11 @@ import com.intellij.execution.process.ProcessOutputType;
 import com.intellij.execution.testframework.TestConsoleProperties;
 import com.intellij.execution.testframework.sm.ServiceMessageBuilder;
 import com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter;
-import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -273,8 +274,8 @@ public class KarateOutputToGeneralTestEventsConverter extends OutputToGeneralTes
         })
         .map(root -> VfsUtil.findRelativeFile(featureName, root)).filter(Objects::nonNull).findFirst()
         .ifPresent(file -> {
-          int lineNumber = ReadAction.compute(
-            () -> {
+          int lineNumber = ApplicationManager.getApplication()
+            .runReadAction((Computable<Integer>) () -> {
               PsiFile psiFile = PsiManager.getInstance(testConsoleProperties.getProject()).findFile(file);
               if (psiFile == null) {
                 return -1;


### PR DESCRIPTION
- Replace ReadAction.compute(ThrowableComputable) with ApplicationManager.runReadAction(Computable) in GherkinSuppressionUtil, CucumberUtil, and KarateOutputToGeneralTestEventsConverter
- Remove deprecated PositionManager.getAcceptedFileTypes() override in KaratePositionManager
- Replace ThrowableComputable cast with Computable in KaratePositionManager
- Bump version to 2.5.0