### PR TITLE
Fix both integration tests for headless Linux CI

### DIFF
--- a/docs/KARATE2-HANDOFF.md
+++ b/docs/KARATE2-HANDOFF.md
@@ -31,6 +31,27 @@ event stream.
   and the settings override displacing detection. Also asserts the plugin logged no errors.
 - CI runs `integrationTest` only on push, not on pull requests (`.github/workflows/build.yml`).
 
+## First Linux CI run (both failures fixed)
+
+The integration-test job ran for the first time on Linux (previously Windows-only) and both tests
+failed — for reasons in the test harness, not the plugin. Both are fixed on this branch; the
+diagnosis is recorded here so it is not rediscovered:
+
+- **`Karate2UITest` → `initializationError`.** `@BeforeAll` ran
+  `CommandChain().waitForSmartMode().importGradleProject().waitForSmartMode()` to win a race against
+  project-SDK registration. On headless Linux the *startup auto-import wins that race and finishes*
+  (idea.log: resolution task "executed in 66405 ms", JDK_17 applied), so the explicit re-import is
+  redundant and the platform cancels the second sync ("Could not build GradleSourceSetModel model.
+  Build cancelled."), which surfaces as "Gradle sync failed" and, from `@BeforeAll`, fails all seven
+  tests as one error. Fix: the explicit re-import is now wrapped in try/catch and falls back to
+  `waitForSmartMode()` — the guard still helps when auto-import loses, but a cancellation no longer
+  sinks the class.
+- **`UppercutUITest` → `NoSuchElementException: List is empty`.** The legacy v1 test launches the run
+  by clicking the gutter icon; driver clicks are physical (screen coordinates) and land nowhere under
+  headless xvfb, so the gutter lookup is empty. It has been fragile since before this branch. Its v1
+  run path is now covered click-free by `Karate2UITest.v1ModuleRunsThroughTheV1Runner`, so it is
+  `@Disabled` (not deleted) pending a rewrite of `clickRunTest` to `invokeAction("RunClass")`.
+
 ## Bugs this work surfaced (all fixed here)
 
 - **Logback was mandatory.** The shared runner installed its `<<UPPERCUT>>` console appender
@@ -67,8 +88,9 @@ event stream.
 2. Phase 3 polish (see docs/KARATE2.md): `karate-base.js`/`karate-boot.js` recognition,
    README/marketplace description mention of Karate 2, possibly refreshing the embedded karate-js
    sources under `src/main/java/io/karatelabs/js/`.
-3. The integration-test CI job has never run: its YAML was not validated locally, and these tests
-   have only ever run on Windows, never Linux.
+3. ~~The integration-test CI job has never run.~~ It has now run on Linux; see "First Linux CI run"
+   above. `Karate2UITest` is fixed to pass headless and `UppercutUITest` is disabled pending a
+   click-free rewrite.
 
 ## Known issues, deliberately unfixed
 
@@ -81,4 +103,7 @@ event stream.
 
 - Should the v1 bundled-karate fallback also exist for v2 (currently intentionally not)?
 - Marketplace/changelog wording for "experimental" Karate 2 support.
-- Should a failing integration test block the release draft? It does not today.
+- A failing integration test now blocks the release draft: `releaseDraft` has
+  `needs: [ build, test, verify, integration-test ]` in `.github/workflows/build.yml`, and
+  integration-test runs on push. Until the two fixes above land, no draft releases are produced.
+  Confirm this gating is intended, or drop `integration-test` from that `needs` list.

--- a/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/Karate2UITest.kt
+++ b/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/Karate2UITest.kt
@@ -100,8 +100,22 @@ class Karate2UITest {
             // fast with "Invalid Gradle JDK configuration", indicators go quiet, and every run in
             // the session launches against an unimported project (empty classpath, no modules).
             // An explicit import after the IDE is up cannot lose that race - the SDK is registered
-            // by now - and re-importing an already-imported project is harmless.
-            run.driver.execute(CommandChain().waitForSmartMode().importGradleProject().waitForSmartMode())
+            // by now - and re-importing an already-imported project is normally harmless.
+            //
+            // But when auto-import *wins* - as it reliably does on headless Linux CI, where it
+            // finishes before this line runs - the re-import is redundant, and the platform cancels
+            // the now-pointless second sync ("Could not build GradleSourceSetModel model. Build
+            // cancelled."). That cancellation surfaces here as "Gradle sync failed" and, thrown from
+            // @BeforeAll, fails every test in the class with a single initializationError. Swallow
+            // it and wait out smart mode instead: the project is already imported, so the run tests
+            // proceed. A genuinely unimported project still fails loudly in each test's own run.
+            try {
+                run.driver.execute(CommandChain().waitForSmartMode().importGradleProject().waitForSmartMode())
+            } catch (e: Throwable) {
+                println("Explicit Gradle re-import was not needed (auto-import already completed); " +
+                    "continuing against the imported project: ${e.message}")
+                run.driver.execute(CommandChain().waitForSmartMode())
+            }
         }
 
         @JvmStatic

--- a/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/UppercutUITest.kt
+++ b/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/UppercutUITest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import kotlin.io.path.Path
@@ -30,6 +31,23 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 
+/**
+ * The original v1 UI test. It launches the run from the gutter by clicking the icon, and driver
+ * clicks are physical (screen coordinates): under headless xvfb there is no window to receive them,
+ * so [clickRunTest]'s gutter lookup returns an empty list and the test fails with
+ * NoSuchElementException before it can run anything.
+ *
+ * The v1 run path it exercised is now covered click-free by
+ * [Karate2UITest.v1ModuleRunsThroughTheV1Runner], which launches through invokeAction("RunClass") -
+ * the same action the gutter icon delegates to - and needs no mouse. This class is parked rather than
+ * deleted so its edit-and-rerun flow can be revived once clickRunTest is rewritten the same way.
+ */
+@Disabled(
+    "v1-only test that drives the run gutter with physical driver clicks, which land nowhere under " +
+        "headless CI (clickRunTest -> NoSuchElementException: List is empty). The v1 run path is now " +
+        "covered click-free by Karate2UITest.v1ModuleRunsThroughTheV1Runner; re-enable only after " +
+        "rewriting clickRunTest to launch via invokeAction(\"RunClass\")."
+)
 class UppercutUITest {
 
     companion object {


### PR DESCRIPTION
The `integration-test` job ran for the first time on Linux (run #29725256693, a `workflow_dispatch` on `claude/karate2-spike`) and both UI tests failed. Both are harness bugs, not plugin defects. This targets `claude/karate2-spike` so PR #334's own runs pick up the fixes.

## Root causes (confirmed from CI logs + the `integration-tests-result` artifact's `idea.log`)

**`Karate2UITest` → `initializationError` (all 7 tests failed as one error)**
The `@BeforeAll` ran an explicit `importGradleProject()` to win a race against project-SDK registration. On headless Linux the startup **auto-import wins that race and completes** — `idea.log` shows the resolution task `executed in 66405 ms` with `JDK_17` applied and the project renamed. The explicit re-import then starts a **second** sync that the platform **cancels** (`Could not build GradleSourceSetModel model. Build cancelled.`, 820 ms), which surfaces as `Gradle sync failed`. Thrown from `@BeforeAll`, it takes down the whole class.

**`UppercutUITest` → `NoSuchElementException: List is empty`**
It launches the run by clicking the gutter icon, but driver clicks are physical screen coordinates that land nowhere under headless xvfb, so the gutter lookup is empty. This is the exact anti-pattern the `ide-integration-tests` skill warns against.

## Changes

- **`Karate2UITest`**: wrap the explicit re-import in `try/catch`, falling back to `waitForSmartMode()`. The guard still helps when auto-import *loses* the race, but a redundant cancellation no longer sinks the class.
- **`UppercutUITest`**: `@Disabled` (not deleted) with a reason pointing at the fix. Its v1 run path is now covered click-free by `Karate2UITest.v1ModuleRunsThroughTheV1Runner`; parked so its edit-and-rerun flow can be revived once `clickRunTest` is rewritten to `invokeAction("RunClass")`.
- **`docs/KARATE2-HANDOFF.md`**: record the first Linux run and correct two now-stale notes (that the job had never run on Linux; that a failing integration test does not block the release draft — `releaseDraft` now `needs: [ …, integration-test ]`).

## Why both matter together

`docs/risks/karate-v1-regressions.md` (R3 + Standing invariants) notes that `Karate2UITest`'s v1 leg is the **only** end-to-end execution of the v1 runner path. With `UppercutUITest` disabled, `Karate2UITest` becomes the sole v1 regression net — so the import-tolerance fix is what keeps that coverage alive, not just a way to clear the error.

## Validation

Not run locally: the branch's Gradle wrapper (9.6.1) download is blocked by the sandbox proxy, and `integrationTest` needs the ~4 GB IDE. The `integration-test` job runs only on push to `main`/`ij-2024.2` or a manual `workflow_dispatch` (how the failing run was produced) — it won't fire on this PR automatically. **Recommend a `workflow_dispatch` on `claude/integration-tests-linux-ci-v4e6fs` to confirm green before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PevzFzjK9c9iWhiUVUkAHs)_