### PR TITLE
Phase-3 planning: pause-debug design + execution plan

### DIFF
--- a/docs/KARATE2-PHASE3-PLAN.md
+++ b/docs/KARATE2-PHASE3-PLAN.md
@@ -1,0 +1,146 @@
+# Karate 2 phase-3 execution plan
+
+Handoff for a session with the **full build/test toolchain** (local machine). It was authored in a
+sandbox that could not run Gradle or the IDE, so every step here ends in a verification command the
+author could not run — **run them.** All API facts were verified with `javap` against
+`karate-core-2.1.1.jar` / `karate-js-2.1.1.jar` from Maven Central.
+
+## Context transfer — read these first
+
+This repo *is* the handoff; the chat that produced it does not travel with you. Before starting, read:
+
+- `docs/karate2-pause-debugging.md` — full design for Task 4 (pause-only debugging).
+- `docs/KARATE2.md` — architecture, verified v2 API surface, phase table.
+- `docs/KARATE2-HANDOFF.md` — current state, gotchas already paid for.
+- `.claude/skills/karate-version-parity/` — how to diff the plugin's syntax knowledge against the jar.
+- `.claude/skills/inspect-dependency-apis/` — the `javap` recipes used below (docs for intent, jars for truth).
+
+Work on `claude/karate2-spike` (PR #334) or feature branches that PR into it — this is Karate 2
+feature work, not the (merged) integration-tests fix.
+
+**Verification loop you have and the author didn't:** `./gradlew test` (runs `UppercutLexerTest` +
+the conformance suite), `./gradlew runIde` (eyeball highlighting/behavior), `./gradlew integrationTest`
+(the IDE-driver suite). Use them after every task; nothing below is verified.
+
+## Priority order (per the user)
+
+1. **Karate 2 new JS syntaxes** — the priority. Detailed below.
+2. `karate-base.js` / `karate-boot.js` recognition.
+3. README / marketplace mention of Karate 2.
+4. Pause-only debug prototype (see the separate design note).
+
+---
+
+## Task 1 — Karate 2 new JS syntaxes (embedded lexer/parser)
+
+### Why
+The plugin vendors a copy of the karate-js engine at `src/main/java/io/karatelabs/js/` and uses it to
+lex/parse JS **only on the fallback path when the IntelliJ JavaScript plugin is absent** (see
+`KarateJsNoPluginExtension.java`). That copy predates several JS features karate-js 2.1.1 supports, so
+modern JS in `.feature` files mis-highlights on that path.
+
+### Verified gap (do not re-derive)
+`io.karatelabs.js.Token` (vendored) = **95** token constants. karate-js 2.1.1 reorganized tokens to
+`io.karatelabs.parser.TokenType` = **118**. The 23-token delta is:
+
+**The 9 JS-syntax tokens that matter — add these:**
+
+| Token | Syntax | Notes |
+|---|---|---|
+| `QUES_DOT` | `?.` optional chaining | New operator; also `?.[` and `?.(` forms. Lexer + member/call grammar. |
+| `QUES_QUES_EQ` | `??=` nullish assignment | New assignment op. Vendored already has `QUES` and `QUES_QUES`. |
+| `CLASS` | `class` declaration | Keyword + a class-body grammar rule. Largest single addition. |
+| `EXTENDS` | `extends` | Keyword; only meaningful inside a class heritage clause. |
+| `SUPER` | `super` | Keyword; `super.x` / `super(...)` expression. |
+| `THIS` | `this` | Keyword; primary expression. |
+| `CONTINUE` | `continue` | Keyword; statement, parallels existing `BREAK`. |
+| `VOID` | `void` | Keyword; unary operator, parallels existing `TYPEOF`/`DELETE`. |
+| `BIGINT` | `123n` literal | Number-like literal; lexer rule beside `NUMBER`. |
+
+(`EOF` is a structural token — add if the ported lexer expects it. The other 13 new constants are all
+`G_*` — karate-js 2.1.1's *own Gherkin* tokens: `G_FEATURE`, `G_SCENARIO`, `G_TABLE_CELL`, etc. **The
+plugin lexes Gherkin itself** — see the `karate/lexer/` package — so the embedded engine's Gherkin
+tokens are irrelevant here. Do **not** pull them in.)
+
+### Approach — surgical, not wholesale
+**Add the 9 tokens to the existing `io.karatelabs.js` structure.** Do **not** wholesale re-vendor from
+2.1.1: it moved tokens to `io.karatelabs.parser.TokenType`, split into `io.karatelabs.common` /
+`io.karatelabs.parser` packages, and would collide with the plugin's own additions (e.g.
+`KarateJsNoPluginExtension`). You only need the fallback lexer/parser to *recognize* the new syntax so
+it highlights and doesn't red-underline valid code — not the whole engine reorg.
+
+Get the reference behavior from karate-js 2.1.1 **sources** (try the Maven `:sources` classifier, else
+GitHub `karatelabs/karate-js` at the 2.1.1 tag) and port the per-token lexer/parser handling.
+
+### Files to touch
+- `src/main/java/io/karatelabs/js/Token.java` — add the 9 enum constants (keywords vs punctuation;
+  mirror how `BREAK`/`TYPEOF`/`QUES_QUES` are declared).
+- `src/main/java/io/karatelabs/js/Lexer.java` — tokenize `?.`, `??=`, the new keywords, and the `n`
+  BigInt suffix. Watch ordering: `?.` must not be mis-split into `QUES`+`DOT`, and `??=` must win over
+  `QUES_QUES`; longest-match ordering matters (see how `GT_GT_GT_EQ` is handled).
+- `src/main/java/io/karatelabs/js/Terms.java` + `Parser.java` — grammar/AST rules: optional-chaining
+  member/call access, `class`/`extends` declaration + body, `this`/`super` primaries, `continue`
+  statement, `void` unary, BigInt literal.
+- `src/main/java/io/karatelabs/js/Interpreter.java` — only if you want the fallback engine to *evaluate*
+  them; for highlighting-only, parsing without eval is enough. Decide based on whether the fallback
+  engine is used for anything beyond syntax highlighting (grep usages of `Engine`/`Interpreter` in
+  `src/main`).
+- Highlighter: the JS syntax-highlighter that maps these tokens to colors — likely under
+  `src/main/kotlin/com/rankweis/uppercut/karate/highlight/`. New keywords must map to the keyword color;
+  new operators to the operator color.
+- Preserve plugin-only files in the package (e.g. `KarateJsNoPluginExtension.java`) — do not overwrite.
+
+### Acceptance
+- Add fixtures under `src/test/testData/` exercising each: `a?.b`, `a ??= b`, `class A extends B { constructor(){ super() } m(){ return this.x } }`, `for(...){ continue }`, `void 0`, `10n`.
+- `./gradlew test` green — especially `UppercutLexerTest` and the conformance suite (parity skill:
+  "Add any new action word to a fixture so the lexer test actually sees it").
+- `./gradlew runIde`, open a `.feature` with these in a JS block **with the IntelliJ JavaScript plugin
+  disabled** (the fallback path), and confirm correct highlighting and no false error annotations.
+
+---
+
+## Task 2 — `karate-base.js` / `karate-boot.js` recognition
+
+Karate 2 introduces `karate-base.js` and `karate-boot.js` as bootstrap config files alongside
+`karate-config.js`. Make the plugin treat them like `karate-config.js`.
+
+- Grep for `karate-config.js` across `src/main` — extend every special-case (config-file detection,
+  navigation, run-classpath, any completion/inspection that keys off the name) to also match
+  `karate-base.js` and `karate-boot.js`. Prefer a single shared constant/set over scattered literals.
+- Confirm against karate-js/karate 2 docs what each does (base = shared config, boot = startup) so the
+  handling is right, not just name-matched.
+- Acceptance: `./gradlew runIde`, add the files to a v2 project, confirm they're recognized (navigation
+  / no "unknown config" behavior). Add a unit test if there's an existing config-detection test.
+
+---
+
+## Task 3 — README / marketplace mention of Karate 2
+
+- `README.md`: add a short "Karate 2 (early access)" section — per-module detection, run/report works,
+  debugging limitation. Mirror the CHANGELOG `[Unreleased]` early-access wording (already written).
+- Plugin marketplace description: the `<description>` in `src/main/resources/META-INF/plugin.xml` (or
+  the `patchPluginXml { pluginDescription }` block in `build.gradle.kts` if that's the source of truth —
+  check which wins). Keep it honest about "early access".
+- Acceptance: `./gradlew buildPlugin` / `verifyPlugin` still pass; description renders (no broken HTML).
+
+---
+
+## Task 4 — Pause-only debug prototype
+
+Follow `docs/karate2-pause-debugging.md` in full. Summary: wire
+`Runner.builder().debugSupport(RunInterceptor, DebugPointFactory)` in `KarateV2TestRunner` (reflection/
+proxy, as with the existing `RunListener`); pause a `GHERKIN_STEP` by returning `WAIT` from
+`beforeExecute` and blocking in `waitForResume`; a thin socket carries breakpoints in and "paused"/
+"resume" out; a minimal `XDebugProcess` + `.feature` `XLineBreakpointType` + a v2 debug `ProgramRunner`
+show the paused line and a Resume button. **Force `parallel(1)` under debug.** No variables/stepping/eval.
+
+Prototype the runner↔IDE socket first (the one real unknown), then the XDebugger UI. Verify with
+`./gradlew runIde`: set a breakpoint on a step, confirm the run pauses there and Resume continues. Keep
+the v1 debugger (`debugging/KaratePositionManager`, `KarateDebugAware`) untouched — it's the v1/JDI path.
+
+---
+
+## Suggested sequencing
+
+Task 1 is the priority and is self-contained — do it first, get `./gradlew test` green, PR it. Tasks 2
+and 3 are small and low-risk. Task 4 is the big one; treat its walking skeleton as its own PR.

--- a/docs/KARATE2.md
+++ b/docs/KARATE2.md
@@ -83,7 +83,7 @@ IDE console (phase 2)
 | 2 | `KarateV2EventProcessor` (JSON events -> id-based test tree), nesting via callDepth, failure mapping, unit tests | done |
 | 2b | `Karate2UITest` end-to-end integration test (IDE Starter/Driver); covers both runner paths, the failure path, and the settings override. Surfaced the logback and project-wide-detection bugs | done |
 | 3 | Editor niceties: `karate-base.js`/`karate-boot.js` recognition, README/docs, refresh embedded karate-js source | |
-| later | Real debugging via v2 `debugSupport(RunInterceptor, DebugPointFactory)` | |
+| later | Debugging via v2 `debugSupport(RunInterceptor, DebugPointFactory)`. Pause-only scope (breakpoint suspends a step, Resume continues; no variables/stepping) is designed in `docs/karate2-pause-debugging.md` | designed, not started |
 
 ## Spike results — all questions ANSWERED (live run against karate 2.1.1)
 

--- a/docs/karate2-pause-debugging.md
+++ b/docs/karate2-pause-debugging.md
@@ -1,0 +1,166 @@
+# Karate 2 pause-only debugging — design note
+
+Status: **design, not started.** Scope deliberately limited to *pausing* — a breakpoint on a
+Gherkin step suspends the run, the editor shows where it stopped, and Resume/Stop continue it.
+**No variable inspection, no stepping, no expression evaluation.** Those are noted at the end as
+later extensions, because the chosen API leaves the door open, but they are out of scope here.
+
+API facts below were verified with `javap` against the real `karate-core-2.1.1.jar` and
+`karate-js-2.1.1.jar` from Maven Central, not from docs.
+
+## Goal
+
+- A line breakpoint on a step in a `.feature` file run under the **v2** runner pauses the run before
+  that step executes.
+- The IDE shows the paused state and highlights the current line.
+- Resume continues; Stop ends the run.
+- v1 debugging is untouched (it keeps its own, entirely separate path — see below).
+
+## Why v1's debugger cannot be reused
+
+v1 debugging does **not** use Karate's DAP server. It uses plain JVM **JDWP** plus a custom
+`KaratePositionManager`
+(`src/main/java/com/rankweis/uppercut/karate/debugging/KaratePositionManager.java`) that reflects
+`com.intuit.karate.core.StepRuntime.findMethodsMatching(...)` to map a Gherkin step to the **Java
+bytecode location** of the step method, then arms a JDI breakpoint there. The registrations are two
+platform hooks in `plugin.xml` (`debugger.javaDebugAware` line 174, `debugger.positionManagerFactory`
+line 176); there is no custom breakpoint type, program runner, or DAP client.
+
+That works only because v1 executes each step as a discrete Java method in-process. v2 executes steps
+through the **karate-js interpreter** (`io.karatelabs.js.Interpreter`, virtual threads) — there are no
+per-step Java methods and no stable bytecode locations to bind JDI to. `StepRuntime.findMethodsMatching`
+does not exist in v2. **The v1 debugger is a dead end for v2 and must not be touched or extended for it.**
+
+## Routes considered
+
+| Route | Verdict |
+|---|---|
+| JDWP + a v2 `PositionManager` (v1's approach) | ❌ No step→bytecode mapping in v2's karate-js engine. |
+| Karate 2's built-in debug server (`-Dkarate.debug.port` → `io.karatelabs.debug.Main`, DAP) | ❌ `Runner$Builder` auto-delegates to it, but that backend ships in a **`karate-ide` jar that is not on Maven Central** (`io/karatelabs/karate-ide` → HTTP 404) — Karate Labs' commercial tooling. Unusable in a free plugin, and would also require a DAP client. |
+| **`debugSupport(RunInterceptor, DebugPointFactory)`** (public `karate-js` API) | ✅ **Chosen.** In-process interceptor, clean, purpose-built. |
+
+## The chosen API (verified)
+
+`io.karatelabs.core.Runner$Builder`:
+
+```
+public <T> Runner$Builder debugSupport(io.karatelabs.js.RunInterceptor<T>,
+                                       io.karatelabs.js.DebugPointFactory<T>);
+```
+
+`io.karatelabs.js.RunInterceptor<T>` (called from `io.karatelabs.js.Interpreter`/`Engine`):
+
+```
+RunInterceptor.Action beforeExecute(T point);              // PROCEED | SKIP | WAIT
+default void afterExecute(T point, Object result, Throwable error);
+default RunInterceptor.Action waitForResume();             // PROCEED | SKIP | WAIT
+enum Action { PROCEED, SKIP, WAIT }
+```
+
+`io.karatelabs.js.DebugPointFactory<T>`:
+
+```
+int JS_STATEMENT, JS_EXPRESSION, GHERKIN_STEP;            // point kinds
+T create(int kind, int line, String source, Object a, Object b);
+```
+
+**Pause/resume mechanics (from decompiling `Interpreter`):** for each point the engine calls
+`factory.create(kind, line, source, …)`, then `interceptor.beforeExecute(point)`. If it returns
+`WAIT`, the engine loops on `interceptor.waitForResume()` until that returns non-`WAIT`. So:
+
+- **Pause** = return `WAIT` from `beforeExecute`, then block inside `waitForResume` until the user
+  resumes, at which point return `PROCEED`.
+- For pause-only we care about `kind == GHERKIN_STEP`; JS-level points can be ignored.
+- `create` can return a trivial record of just `(kind, line, source)` — **no execution context is
+  needed for pausing.**
+
+## Architecture
+
+Two processes, one thin socket between them.
+
+```
+IDE (KarateV2DebugProcess : XDebugProcess)                 test JVM (KarateV2TestRunner)
+  XLineBreakpointType<> for .feature                         RunInterceptor + DebugPointFactory
+  breakpoint set  ──────────────── socket ───────────────▶   beforeExecute: is source:line a bp?
+  "paused at path:line"  ◀───────────────────────────────    yes → WAIT, block in waitForResume
+  Resume  ────────────────────────────────────────────────▶  waitForResume returns PROCEED
+  (editor highlights path:line; Debug toolwindow Resume/Stop)
+```
+
+### Runner side (`KarateTestRunner/.../KarateV2TestRunner.java`) — small
+- Add `.debugSupport(interceptor, factory)` to the reflective builder chain in `doTest`, built with
+  the same dynamic-proxy style already used there for `RunListener` (no compile-time Karate dep).
+- `DebugPointFactory.create` → a tiny `{kind, line, source}` holder.
+- `RunInterceptor.beforeExecute`: for a `GHERKIN_STEP`, look up `source:line` in the breakpoint set
+  received from the IDE; if present, send `paused` over the socket and return `WAIT`. `waitForResume`
+  blocks on a latch/queue until the IDE sends `resume`, then returns `PROCEED`.
+- Only wired when a new `--debug` flag (and a debug port/socket) is passed; otherwise the builder is
+  unchanged, so normal runs are unaffected.
+
+### IDE side (new; the bulk, but minimal)
+- `XLineBreakpointType` for Karate `.feature` files (v2 wants XDebugger-native breakpoints, not the
+  Java line breakpoints v1 rides on via `JavaDebugAware`).
+- `KarateV2DebugProcess extends XDebugProcess` + an `XBreakpointHandler`. The suspend context has a
+  **single stack frame that is just the source position** (`XStackFrame` with the `.feature` line, no
+  children) — that frame is what highlights the paused line. No variable tree, no evaluator.
+- A `ProgramRunner`/executor for the v2 **Debug** action that launches `KarateTestRunner` with the
+  `--debug` flag + a socket, instead of the JDWP agent v1 uses. Route to it only when the run's module
+  is v2 (reuse the per-module detection in `KarateRunConfiguration`); v1 keeps its existing path in
+  `KarateRunConfiguration.getState`/`startProcess`
+  (`src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java`).
+- New `plugin.xml` registrations for the breakpoint type and the program runner. The existing
+  `debugger.javaDebugAware` / `debugger.positionManagerFactory` entries stay v1-only.
+
+### Protocol (minimal, one socket)
+- IDE → runner: breakpoint set — `{path, line}` pairs (sent at start; optionally on change).
+- runner → IDE: `paused {path, line}`.
+- IDE → runner: `resume`.
+- Plus session start / process-exit, which the launch already gives.
+
+## The one decision that keeps it small
+
+**Force `parallel(1)` when launched under Debug.** v2 runs scenarios on virtual threads and the
+interceptor is shared; concurrent pauses are the hardest part of a full debugger. Single-threaded
+under debug removes that entirely and matches how v1 debugging already behaves (JDWP `suspend=y`
+freezes the whole VM). Bake this into the v2 debug launch.
+
+## Source-line resolution — already solved
+
+Mapping a paused `path:line` back to the editor is the same source-root problem the test tree already
+handles for `locationHint` (the #321 fix: resolve to the source `.feature`, not the `build/resources`
+copy). Reuse that resolver; do not reinvent it, and do not navigate into the build-output copy.
+
+## What this is not, and what it enables later
+
+Out of scope now, but the chosen API supports them, so the walking skeleton should not preclude them:
+
+- **Variables.** `io.karatelabs.js.Context` (reachable from the point the engine passes to `create`)
+  exposes `getScope()` (variables), `getParent()`+`getDepth()` (call stack), `getNode()`,
+  `getThisObject()`, return/error values. A later version can populate `XStackFrame` children from
+  `getScope()` and a multi-frame stack from the `getParent()` chain.
+- **Stepping.** Only `PROCEED`/`SKIP`/`WAIT` exist, so step over/into/out must be synthesised IDE-side
+  by "pause at the next point at depth ≤/=/> current" using `Context.getDepth()`. Fiddly; deferred.
+- **Expression evaluation.** karate-js can eval in a `Context`, so an evaluator is feasible later.
+
+## Effort & risks
+
+- **Rough size: a few days to ~a week** for the walking skeleton (breakpoint pauses, line highlights,
+  Resume/Stop). Most of that is the minimal `XDebugProcess`/breakpoint-type boilerplate and the socket
+  protocol; the runner side is small.
+- **No automated coverage is possible** with the current harness — debuggers can't be driven by it, so
+  this needs the manual checklist (like v1 debugging), and ideally a later IDE-driver test that sets a
+  breakpoint and asserts a pause.
+- **Main unknown:** the exact `--debug` launch wiring and keeping the socket lifecycle clean on abrupt
+  process death. Prototype the runner↔IDE channel first (it's the one true unknown) before building
+  out the XDebugger UI.
+
+## Concrete first hook points
+
+- `KarateTestRunner/src/main/java/com/rankweis/uppercut/testrunner/KarateV2TestRunner.java` — add
+  `debugSupport` to the reflective builder in `doTest`; implement the interceptor + factory + socket.
+- `src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java` — a v2 debug launch that
+  passes `--debug`/socket instead of the JDWP agent, gated on v2 module detection.
+- `src/main/resources/META-INF/plugin.xml` — register the new `XLineBreakpointType` and program runner
+  (leave the v1 `debugger.*` entries alone).
+- Do **not** modify `debugging/KaratePositionManager.java`, `KarateDebugAware.java`, or
+  `UppercutClassLoader.java` — those are the v1/JDI path.


### PR DESCRIPTION
Docs only — no code. Two planning notes to hand the remaining Karate 2 work off to a session with the full build/test toolchain (this sandbox can't run Gradle or the IDE).

- **`docs/karate2-pause-debugging.md`** — design for **pause-only** v2 debugging (breakpoint suspends a Gherkin step, Resume continues; no variables/stepping/eval). Verified against the 2.1.1 jars: the route is `Runner.builder().debugSupport(RunInterceptor, DebugPointFactory)` (in-process interceptor; `WAIT` + `waitForResume` is the pause primitive). Explains why v1's JDWP+PositionManager can't be reused and why Karate 2's built-in debug server isn't an option (its `karate-ide` backend isn't on Maven Central). Includes the `force parallel(1)` simplification and concrete hook points.
- **`docs/KARATE2-PHASE3-PLAN.md`** — priority-ordered execution plan (new JS syntaxes first, then `karate-base.js`/`karate-boot.js` recognition, README/marketplace copy, pause-debug prototype). Carries the **verified token gap**: `io.karatelabs.js.Token` (vendored, 95) vs `io.karatelabs.parser.TokenType` (karate-js 2.1.1, 118) — the 9 JS tokens to add (`?.`, `??=`, `class`/`extends`/`super`/`this`, `continue`, `void`, BigInt) and why the 13 `G_*` Gherkin tokens are out of scope. Recommends a surgical addition over a wholesale re-vendor (2.1.1 reorganized the token packages), with per-file guidance and a `./gradlew test` acceptance check for each task.
- Links the plan from `KARATE2.md`'s phase table.

Intended as the starting point for local execution, not to merge as-is unless you want the docs in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PevzFzjK9c9iWhiUVUkAHs)_