### PR TITLE
Updating caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,12 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
+        with:
+          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
+          # re-created from the cached archive in under a minute; caching it as well blew the
+          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
+          gradle-home-cache-excludes: |
+            caches/*/transforms
 
       # Set environment variables
       - name: Export Properties
@@ -116,6 +122,12 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
+        with:
+          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
+          # re-created from the cached archive in under a minute; caching it as well blew the
+          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
+          gradle-home-cache-excludes: |
+            caches/*/transforms
 
       # Run tests
       - name: Run Tests
@@ -172,6 +184,12 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
+        with:
+          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
+          # re-created from the cached archive in under a minute; caching it as well blew the
+          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
+          gradle-home-cache-excludes: |
+            caches/*/transforms
 
       # The downloaded IDE and JDK dominate the runtime. The test boots the platformVersion from
       # gradle.properties, so hashing that file gives a fresh cache on a platform bump.
@@ -227,10 +245,19 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
+        with:
+          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
+          # re-created from the cached archive in under a minute; caching it as well blew the
+          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
+          gradle-home-cache-excludes: |
+            caches/*/transforms
+          # Read-only: the two verifier IDEs are ~2.4 GB of archives that change with every EAP
+          # build. Restoring another job's entry gives this one the platform and dependencies; the
+          # verifier IDEs are downloaded fresh each run rather than kept in the shared budget.
+          cache-read-only: true
 
-      # The IDEs the verifier runs against are Gradle dependencies (~/.gradle/caches), so they are
-      # covered by setup-gradle's cache above; there is no separate verifier IDE cache to keep. Which
-      # IDEs: see pluginVerification in build.gradle.kts.
+      # The IDEs the verifier runs against are Gradle dependencies, downloaded here (see the cache
+      # note above). Which IDEs: see pluginVerification in build.gradle.kts.
       - name: Run Plugin Verification tasks
         run: ./gradlew verifyPlugin
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
     outputs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}
-      pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
 
       # Check out the current repository
@@ -69,7 +68,6 @@ jobs:
           CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
           
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
@@ -230,17 +228,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
 
-      # IntelliJ will verify Plugin for us and this is a lot of downloading.
-      # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
-
-      # Run Verify Plugin task and IntelliJ Plugin Verifier tool
+      # The IDEs the verifier runs against are Gradle dependencies (~/.gradle/caches), so they are
+      # covered by setup-gradle's cache above; there is no separate verifier IDE cache to keep. Which
+      # IDEs: see pluginVerification in build.gradle.kts.
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,11 @@ Uppercut is an IntelliJ IDEA plugin providing comprehensive IDE support for the 
 # Launch IntelliJ with the plugin loaded for manual testing
 ./gradlew runIde
 
-# Verify plugin compatibility
+# Verify plugin compatibility against the newest release + newest EAP (what CI runs)
 ./gradlew verifyPlugin
+
+# ... against every supported major, since-build up to the newest EAP (before a release)
+./gradlew verifyPlugin -PpluginVerifierScope=all
 
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,7 +212,26 @@ intellijPlatform {
     }
     pluginVerification {
         ides {
-            recommended()
+            // Every push verifies against the newest release and the newest EAP of the platform major
+            // the plugin is built on - the two builds that can break it after it compiled - and
+            // nothing older: with no until-build, `recommended()` would otherwise add one ~1.2 GB IDE
+            // per major release from since-build up, forever. The full support range is one flag away
+            // for a release check by hand:
+            //
+            //   ./gradlew verifyPlugin -PpluginVerifierScope=all
+            //
+            if (properties("pluginVerifierScope").orNull == "all") {
+                recommended()
+            } else {
+                select {
+                    types = listOf(IntelliJPlatformType.IntellijIdeaUltimate)
+                    channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
+                    // "2026.2" -> "262": the platform's own major build, so the list follows platformVersion
+                    sinceBuild = properties("platformVersion").map { v ->
+                        v.split('.').let { (year, minor) -> year.takeLast(2) + minor }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- **Verify against the newest release and EAP by default, the full range on request**
- **Keep the CI cache inside GitHub's 10 GB budget**
