### PR TITLE
Stop the CI cache thrash: own the dependency submission, cache the CodeQL build, plus two dependabot bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
@@ -110,7 +110,7 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -172,7 +172,7 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -233,7 +233,7 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -291,7 +291,7 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,16 @@ jobs:
           distribution: zulu
           java-version: 25
 
+      # The manual build below resolves the IntelliJ platform (~2 GB). Without this the CodeQL job
+      # downloads it from scratch on every run, since it is the one workflow here that builds
+      # without setting Gradle up. Read-only: build.yml populates these entries, and this job must
+      # not add a third copy to the repository's 10 GB cache budget.
+      - name: Setup Gradle
+        if: matrix.language == 'java-kotlin'
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Java
         if: matrix.language == 'java-kotlin'

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,51 @@
+# Submits the Gradle dependency graph to GitHub so Dependabot can see the project's dependencies.
+#
+# This replaces the repository's "Automatic dependency submission" setting (Settings -> Code
+# security), which runs the same action through a workflow we cannot configure: it sets up its own
+# temurin JDK and writes its own Gradle cache entry, a second full copy of the dependency set
+# (~3.3 GB) scoped to whatever branch it ran on. Two open dependabot PRs were enough to push the
+# repository past its 10 GB cache budget and evict everything - the same failure the
+# gradle-home-cache-excludes in build.yml exists to avoid.
+#
+# Running it here, on main only and with the cache read-only, submits the same graph and writes
+# nothing to the cache.
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  # Required to submit the dependency snapshot.
+  contents: write
+
+jobs:
+  dependency-submission:
+    name: Submit Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Fetch Sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Setup Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c
+        with:
+          distribution: zulu
+          java-version: 25
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@9c971963bec38e04b3d30dcc455b5382be2fdbfb
+        with:
+          # Read the caches the build jobs already populated, write nothing back: this job resolves
+          # every configuration, so its Gradle home is the largest of any job in the repository.
+          cache-read-only: true
+          # Skip the artifact upload; the snapshot goes straight to the API.
+          dependency-graph: generate-and-submit
+          gradle-home-cache-excludes: |
+            caches/*/transforms

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       # The github-pages gem bundle: Jekyll plus jekyll-remote-theme for just-the-docs
       - name: Build with Jekyll
@@ -38,7 +38,7 @@ jobs:
           destination: ./_site
 
       - name: Upload site
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   deploy:
     name: Deploy to Pages
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/platform-freshness.yml
+++ b/.github/workflows/platform-freshness.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Compare
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       # Set up Java environment for the next steps
       - name: Setup Java

--- a/.github/workflows/ui-tests-latest.yml
+++ b/.github/workflows/ui-tests-latest.yml
@@ -32,7 +32,7 @@ jobs:
           large-packages: false
 
       - name: Fetch Sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Setup Java
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,8 +80,8 @@ dependencies {
     integrationTestImplementation(libs.junitJupiter)
     // IDE Starter/Driver integration tests are written in Kotlin (see docs: integration-tests-intro)
     integrationTestImplementation(kotlin("stdlib"))
-    integrationTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1")
-    integrationTestImplementation("org.kodein.di:kodein-di-jvm:7.26.1")
+    integrationTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.11.0")
+    integrationTestImplementation("org.kodein.di:kodein-di-jvm:7.33.0")
     // Starter's TeamCityReporter needs it at runtime; not pulled in transitively (intellij-dependencies repo)
     "integrationTestRuntimeOnly"("org.jetbrains.teamcity:serviceMessages:2024.07")
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,8 @@ grammarkit = "2023.3.0.4"
 # plugins
 changelog = "2.5.0"
 gradleIntelliJPlugin = "2.18.1"
-kotlin = "2.3.20"
-qodana = "2026.2.0"
+kotlin = "2.4.10"
+qodana = "2026.2.1"
 lombok = "9.5.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Four commits, all aimed at the same thing: the repository was sitting at **16.2 GB against its 10 GB Actions cache budget**, so GitHub was evicting entries continuously and jobs re-downloaded the IntelliJ platform every run — the exact failure the `gradle-home-cache-excludes` comments in `build.yml` were added to prevent.

| | |
|---|---|
| `d62e2aa` | build(deps): bump the gradle-deps group with 5 updates (#356) |
| `8092da5` | build(deps): bump the github-actions group with 4 updates (#357) |
| `0655e64` | Submit the dependency graph ourselves, read-only against the cache |
| `b286969` | Set Gradle up in the CodeQL job so it stops re-downloading the platform |

## Owning the dependency submission

The cache blowout was not caused by any workflow in this repo. GitHub's **Automatic dependency submission** setting runs `gradle/actions/dependency-submission` through a synthetic workflow (`dynamic/dependency-graph/auto-submission`) that we cannot configure. It sets up its own temurin-21 JDK and writes its own Gradle cache entry — a second full copy of the dependency set, ~3.3 GB — scoped to whatever branch it ran on:

```
3334MB  Linux-jdk21-temurin-gradle-…  refs/heads/dependabot/gradle/gradle-deps-8478a8a12f
3329MB  Linux-jdk21-temurin-gradle-…  refs/heads/dependabot/github_actions/github-actions-e15fd9b832
```

Branch-scoped, so no build on `main` could ever restore them, and the two dependabot PRs below were enough on their own to blow the budget.

`.github/workflows/dependency-submission.yml` runs the same action from a workflow we control:

- **`main` only** — the graph is only meaningful for the default branch, so dependabot branches stop producing copies.
- **`cache-read-only: true`** — this job resolves every configuration, so its Gradle home is the largest of any job here. It now reads what the build jobs already wrote and writes nothing back.
- **`dependency-graph: generate-and-submit`** — skips the workflow-artifact upload; the snapshot goes straight to the API.
- Same `caches/*/transforms` exclude, same pinned action SHAs, and zulu 25 to match the project toolchain instead of a second JDK.

## Caching the CodeQL build

`codeql.yml` was the one workflow here that runs a Gradle build with no `setup-gradle` step, so its manual build resolved the IntelliJ platform — about 2 GB — from scratch on every push and every pull request. It now restores what `build.yml` already writes, read-only, so it costs the cache budget nothing.

The `Cannot build an overlay database because build-mode is set to "manual"` notice is deliberately left alone. Overlay (improved incremental) analysis requires buildless extraction — `IncompatibleBuildMode` is an explicit disable reason in `codeql-action`'s `src/overlay/diagnostics.ts` — but `build-mode: none` does not support Kotlin. With `src/integrationTest/kotlin` present the action would either skip it or fall back to autobuild, trading a controlled build for a guess plus inaccurate dependency inference against the platform API. The notice is informational; the analysis succeeds.

## The dependabot commits

Cherry-picked unchanged, dependabot authorship preserved. They're here rather than on their own branches because #357 bumps `actions/checkout` across every workflow and the new file has to move with it — it's written against the bumped SHA (`3d3c42e5`), so all three workflows agree. Every action SHA in the new file matches what the rest of `.github/workflows/` uses after the bump.

**#356 and #357 can be closed as superseded once this merges.**

## Manual step required

Turn off **Settings → Code security → Automatic dependency submission**. There is no API for that toggle, and until it is off both this workflow and the built-in one will run.

## Also done outside this PR

Deleted the two dependency-submission caches above plus three superseded `gradle-dependencies-v2` snapshots on `main`: **24 caches / 16.2 GB → 19 caches / 4.2 GB**.

## Verification

`action.yml` at the pinned SHA (`9c97196`) was checked directly for the `cache-read-only`, `dependency-graph` and `gradle-home-cache-excludes` input names and for `generate-and-submit` being a valid value; the Kotlin limitation is from GitHub's own compiled-languages docs. Both YAML files parse. No CHANGELOG entry — CI-only changes don't get one here (`2daec77`, `46e3014`).
