### PR TITLE
Cache the verifier IDEs, and give pull requests the narrow scope they were promised

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,19 +251,52 @@ jobs:
           # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
           gradle-home-cache-excludes: |
             caches/*/transforms
-          # Read-only: the two verifier IDEs are ~2.4 GB of archives that change with every EAP
-          # build. Restoring another job's entry gives this one the platform and dependencies; the
-          # verifier IDEs are downloaded fresh each run rather than kept in the shared budget.
+          # Read-only: restoring another job's entry gives this one the platform and dependencies.
+          # The verifier IDEs are cached separately below rather than through this entry, which
+          # would also duplicate the ~2 GB dependency set the build and test jobs already keep.
           cache-read-only: true
 
-      # The IDEs the verifier runs against are Gradle dependencies, downloaded here (see the cache
-      # note above). Which IDEs: see pluginVerification in build.gradle.kts.
+      # The verifier IDEs are Gradle dependencies, resolved under the `idea:idea` coordinate - the
+      # platform the plugin builds against is `idea:ideaIU`, cached with the dependencies above, so
+      # this path holds the verifier's IDEs and nothing else.
+      #
+      # pluginVerification selects RELEASE channels only (EAP is deliberately absent - see
+      # build.gradle.kts), so the set turns over when JetBrains ships a patch release, not with
+      # every EAP build. The key therefore rotates monthly on top of gradle.properties, which is
+      # what decides the window: one live entry of ~2.4 GB most of the time, two briefly at a
+      # rollover, against a 10 GB repository budget.
+      - name: Verifier IDE cache key
+        id: verifier-ides-key
+        run: echo "month=$(date -u +%Y-%m)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore verifier IDEs
+        id: verifier-ides
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.gradle/caches/modules-2/files-2.1/idea/idea
+          key: verifier-ides-${{ runner.os }}-${{ hashFiles('gradle.properties') }}-${{ steps.verifier-ides-key.outputs.month }}
+          restore-keys: verifier-ides-${{ runner.os }}-${{ hashFiles('gradle.properties') }}-
+
       - name: Run Plugin Verification tasks
         # Pull requests verify against the newest release only; a merge to main widens to the
         # last three majors. See pluginVerification in build.gradle.kts.
+        #
+        # The non-empty value has to sit in the `&&` slot: GitHub treats '' as falsy, so
+        # `event == 'pull_request' && '' || '-P...'` falls through to the '-P...' on both sides and
+        # every run got the wide scope, pull requests included.
         run: ./gradlew verifyPlugin $SCOPE
         env:
-          SCOPE: ${{ github.event_name == 'pull_request' && '' || '-PpluginVerifierScope=last3' }}
+          SCOPE: ${{ github.event_name != 'pull_request' && '-PpluginVerifierScope=last3' || '' }}
+
+      # Only a push to main writes the entry. A pull request's cache is scoped to its own branch,
+      # where nothing else can restore it, and a pull request verifies against a subset of what
+      # main already holds - so it reads main's entry and writes nothing.
+      - name: Save verifier IDEs
+        if: ${{ github.event_name != 'pull_request' && steps.verifier-ides.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.gradle/caches/modules-2/files-2.1/idea/idea
+          key: verifier-ides-${{ runner.os }}-${{ hashFiles('gradle.properties') }}-${{ steps.verifier-ides-key.outputs.month }}
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result


### PR DESCRIPTION
Two fixes to the `Verify plugin` job, both found by reading what it actually downloaded rather than what the comments claimed.

## The scope switch never worked

```yaml
SCOPE: ${{ github.event_name == 'pull_request' && '' || '-PpluginVerifierScope=last3' }}
```

GitHub treats `''` as falsy. On a pull request this evaluates `true && ''` → `''`, and `''` then loses the `||`, so it falls through to `'-PpluginVerifierScope=last3'` — the same value the push side produces. **Both branches yield the wide scope**, and the narrow pull-request check `2daec77` introduced has never run.

Evidence from run `33999662095`, a `pull_request` event:

```
Verify plugin | SCOPE: -PpluginVerifierScope=last3
Verify plugin | [org.jetbrains.intellij.platform] Filtering releases with since='261', … channels='RELEASE'
Verify plugin | Downloading …/idea-2026.2.2.tar.gz
Verify plugin | Downloading …/idea-2026.1.5.tar.gz
```

Two IDEs for a check that was meant to be one. The fix puts the non-empty value in the `&&` slot, which is the standard way around this:

```yaml
SCOPE: ${{ github.event_name != 'pull_request' && '-PpluginVerifierScope=last3' || '' }}
```

## The IDEs were downloaded fresh every run

The comment justifying `cache-read-only: true` said the verifier IDEs "change with every EAP build". That stopped being true in `2daec77`: `pluginVerification` sets `channels = listOf(ProductRelease.Channel.RELEASE)`, and the comment beside it says so — *"EAP is deliberately absent — JetBrains runs the verifier against EAPs and emails the failures."* Release IDEs turn over when JetBrains ships a patch, not per EAP build, so they are worth caching.

- Cached at `~/.gradle/caches/modules-2/files-2.1/idea/idea` — the verifier's coordinate. The platform the plugin builds against is `idea:ideaIU` and is already covered by the dependency cache, so this path holds the verifier IDEs and nothing else.
- Key rotates monthly on top of `hashFiles('gradle.properties')`, which is what decides the window. One live entry (~2.4 GB) most of the time, two briefly at a rollover.
- **Restore/save split rather than dropping `cache-read-only`.** Flipping that flag would save this job's whole Gradle home — platform, every dependency, and the IDEs, ~4.5 GB — duplicating the ~2 GB the build and test jobs already cache. Writing a second copy of the dependency set under a job-specific key is exactly what put the repository over its 10 GB budget to begin with.
- **Only a push to main saves.** A pull request's cache entry is scoped to its own branch where nothing else can restore it, and after the scope fix a pull request verifies against a subset of what main holds — so pull requests read main's entry and write nothing.

## Why it's worth it

`Verify plugin` is the slowest job in the workflow — **532s**, against 182s for Build and 280s for Test — and ~2.4 GB of that is IDE archives it re-downloads every time.

Note the extraction into `caches/*/transforms` still happens each run; that directory is deliberately excluded from the cache, and `build.yml` puts the re-extraction at under a minute.

## Not changed

`build.gradle.kts`'s "last three majors" wording is left alone. With `pluginSinceBuild = 261` and `platformVersion = 2026.2`, `maxOf(majorsBack("262", 2), "261")` floors the window at 261, so `last3` selects two majors, not three — which the comment right below it already explains ("floored at the plugin's own since-build because verifying against IDEs the plugin declares incompatible with proves nothing").
