### PR TITLE
Build without the build cache in CodeQL, so there is something to trace

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,9 +51,15 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
+      # --no-build-cache is load-bearing. The Setup Gradle step above restores the build cache
+      # along with the dependencies, and CodeQL builds its database by tracing an actual javac
+      # run: with a warm build cache every compile task comes back FROM-CACHE, nothing is compiled,
+      # and `database finalize` fails with "CodeQL detected code written in Java/Kotlin but this
+      # run didn't build any of it" (exit 32). The cache is still worth restoring - it is what
+      # keeps this job from re-downloading the ~2 GB platform - but the compile has to be real.
       - name: Build
         if: matrix.build-mode == 'manual'
-        run: ./gradlew classes
+        run: ./gradlew classes --no-build-cache
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
**Fixes `main`, which is red.** CodeQL has failed on every run since #359 merged (`34000672753` on main, `34000603738` on the PR before it).

## What broke

`b286969` (in #358) added `setup-gradle` to the CodeQL job to stop it re-downloading the ~2 GB platform on every run. That also restores the **local build cache**, and CodeQL builds its database by tracing an actual `javac` invocation. With a warm build cache there is nothing to trace:

```
> Task :generateEffectiveLombokConfig FROM-CACHE
> Task :KarateTestRunner:compileJava FROM-CACHE
> Task :compileJava FROM-CACHE
7 actionable tasks: 3 executed, 4 from cache
```

```
CodeQL detected code written in Java/Kotlin but this run didn't build any of it,
or CodeQL could not process any of it.
##[error]… "codeql database finalize" … Exit code was 32
```

It passed on the pull requests that introduced it because the build cache held no entry for those source states yet. It broke the moment `main` went warm — which is the steady state, so this would have failed on every subsequent run.

## The fix

`./gradlew classes --no-build-cache`.

The restore is still worth keeping — it's what stops the job re-downloading the platform, and the dependency cache hit is unaffected (`Cache hit for: gradle-dependencies-v2-…`, restored in 15s). Only the compile has to be real. The `--no-build-cache` flag is now commented in place so it doesn't get tidied away later.

## Cost

One real compile per CodeQL run, roughly the 1m11s the build step already took. The platform download it avoids is several minutes, so the job is still well ahead of where it was before #358.
