### PR TITLE
Make the build job the only cache writer, and prune what it supersedes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,12 @@ jobs:
           # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
           gradle-home-cache-excludes: |
             caches/*/transforms
+          # Read-only: this job resolves the build's dependencies plus the test classpath, so its
+          # bundle hashes differently from the build job's and the enhanced cache provider stores it
+          # as a second whole entry - 1920 MB against the build job's 1743 MB, for maybe 180 MB of
+          # dependencies the build job does not have. `needs: [ build ]` means the build job has
+          # already written its entry, so this one restores that and re-resolves the difference.
+          cache-read-only: true
 
       # Run tests
       - name: Run Tests
@@ -190,6 +196,11 @@ jobs:
           # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
           gradle-home-cache-excludes: |
             caches/*/transforms
+          # Read-only, for the same reason as the test job: this job resolves the integrationTest
+          # classpath on top of everything else, so its bundle was stored as a third whole entry -
+          # 2101 MB, the largest of the three - for roughly 360 MB the build job does not have.
+          # The IDE Starter downloads are cached separately below and are unaffected by this.
+          cache-read-only: true
 
       # The downloaded IDE and JDK dominate the runtime. The test boots the platformVersion from
       # gradle.properties, so hashing that file gives a fresh cache on a platform bump.

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -1,0 +1,83 @@
+# Deletes superseded Actions cache entries, so the repository stays under its 10 GB budget without
+# GitHub having to LRU-evict for us.
+#
+# GitHub already expires entries unused for 7 days and evicts by least-recently-used once the
+# budget is exceeded, but LRU is blind: when this repository last went over, it evicted the 1.7 GB
+# IDE Starter archive and live dependency bundles indiscriminately and every job re-downloaded.
+# This prunes the entries that are actually dead instead.
+#
+# What counts as dead: an entry that is not the most recent of its family and has not been read for
+# two days. A "family" is the key with its trailing content hash - and any -YYYY-MM stamp - removed,
+# so `gradle-dependencies-v2-<hash>` entries form one family and `verifier-ides-<os>-<hash>-<month>`
+# another. The newest member of every family is never deleted, whatever its age, so a prune can
+# never cost a job its cache; superseded members drop out two days after the last run that read
+# them, rather than the seven GitHub allows.
+name: Prune caches
+
+on:
+  schedule:
+    # Daily, well clear of the usual push traffic.
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List what would be deleted without deleting it
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  # Deleting a cache entry is a write against the Actions API.
+  actions: write
+
+jobs:
+  prune:
+    name: Prune caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete superseded entries
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+          KEEP_UNREAD_SECONDS: '172800' # two days
+        run: |
+          set -euo pipefail
+
+          gh api "repos/$REPO/actions/caches?per_page=100" --paginate \
+            --jq '.actions_caches[] | {id, key, size: .size_in_bytes, used: .last_accessed_at}' \
+            | jq -s '.' > caches.json
+
+          echo "Total: $(jq 'length' caches.json) entries, \
+          $(jq '[.[].size] | add / 1000000 | round' caches.json) MB"
+
+          # Never drop the newest of a family, however old; drop the rest once they go unread.
+          jq -r --argjson cutoff "$(( $(date -u +%s) - KEEP_UNREAD_SECONDS ))" '
+            map(.family = (.key
+                  | sub("-[0-9]{4}-[0-9]{2}$"; "")
+                  | sub("-[0-9a-f]{8,}$"; "")))
+            | group_by(.family)
+            | map(sort_by(.used) | reverse | .[1:]
+                  | map(select((.used | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) < $cutoff)))
+            | flatten
+            | .[] | [.id, .size, .key] | @tsv
+          ' caches.json > prune.tsv
+
+          freed=0
+          while IFS=$'\t' read -r id size key; do
+            [ -n "${id:-}" ] || continue
+            freed=$(( freed + size ))
+            if [ "$DRY_RUN" = 'true' ]; then
+              echo "would delete $key ($(( size / 1000000 )) MB)"
+            else
+              echo "deleting $key ($(( size / 1000000 )) MB)"
+              gh cache delete "$id" --repo "$REPO"
+            fi
+          done < prune.tsv
+
+          count=$(wc -l < prune.tsv | tr -d ' ')
+          verb=$([ "$DRY_RUN" = 'true' ] && echo 'Would free' || echo 'Freed')
+          echo "$verb $(( freed / 1000000 )) MB across $count entries" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Takes the cache budget from **9.34 GB of 10 GB** to roughly 5.3 GB, and keeps it there.

## One writer instead of three

The enhanced cache provider stores the Gradle User Home as content-hashed bundles, so a job whose dependency set differs *at all* gets a whole second copy rather than a delta. Four jobs, three dependency sets, three entries:

| job | entry | delta |
|---|---|---|
| `build` | 1743 MB | — |
| `test` | 1920 MB | +177 MB of test classpath |
| `integration-test` | 2101 MB | +358 MB of integrationTest classpath |

5.8 GB of a 10 GB budget for about 540 MB of distinct content.

Both jobs already `needs: [ build ]`, so the build job's entry is written before either starts. Setting `cache-read-only: true` on them means they restore it and re-resolve only their own extras — a few hundred MB of download per run, ~4 GB of budget back. `verify` was already read-only for exactly this reason; this makes the treatment consistent.

The IDE Starter archive has its own `actions/cache` entry and is untouched by this.

## Pruning what gets superseded

That leaves the entries that go stale, which is what put the repository over budget to begin with: a dependency bump changes the bundle hash and the old one sits there for the seven days GitHub allows. Eviction does happen on its own eventually, but LRU is blind — last time it took the 1.7 GB IDE Starter archive and live bundles with it, and every job re-downloaded.

`prune-caches.yml` (daily, plus `workflow_dispatch` with a `dry_run` input) deletes an entry only when **both** hold:

- it is not the most recent of its family, and
- it has not been read for two days.

A "family" is the key with its trailing content hash — and any `-YYYY-MM` stamp — removed, so all `gradle-dependencies-v2-<hash>` entries form one family and `verifier-ides-<os>-<hash>-<month>` another. The newest member of every family survives regardless of age, so a prune can never cost a job its cache; and while several members are genuinely live they are all read on every run, so the two-day rule never touches them either. The two rules compose: superseded entries drop two days after the last run that read them, instead of seven.

## Verification

Run against the live cache list before committing:

- With the real two-day cutoff it selects **nothing** — every entry there was read today, so a prune run now is correctly a no-op.
- With the cutoff forced to `now`, it selects the superseded members of each family and keeps exactly one, leaving the 3179 MB `verifier-ides` entry alone (a family of one once the month stamp is stripped).

Family grouping on the real keys:

```
3  gradle-dependencies-v2
2  gradle-home-v2|Linux-X64|build[…]
2  gradle-home-v2|Linux-X64|test[…]
1  verifier-ides-Linux
…
```

## Note on the alternative

Folding `test` into `build` gets the same 1.9 GB but costs about four minutes on every pipeline — `verify` and `integration-test` also `needs: [ build ]` and would stop starting at 182s — and it would break the ruleset, which requires a status context named `Test` by name. Read-only gets the saving without either.
