### PR TITLE
Spend the raised cache budget, and stop citing the old one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,15 +54,14 @@ jobs:
           distribution: zulu
           java-version: 25
 
-      # Setup Gradle
+      # Setup Gradle. Nothing is excluded from the Gradle User Home here, and this is the only job
+      # that writes to the cache. The extracted IntelliJ platform (caches/<gradle>/transforms,
+      # ~1.4 GB) used to be excluded: caching it as well overran the old 10 GB budget and everything
+      # got evicted, so every run re-downloaded regardless. With 25 GB and a single writer it is
+      # cached once, and the read-only jobs below restore it rather than each spending a minute
+      # re-extracting it from the archive.
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
-        with:
-          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
-          # re-created from the cached archive in under a minute; caching it as well blew the
-          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
-          gradle-home-cache-excludes: |
-            caches/*/transforms
 
       # Set environment variables
       - name: Export Properties
@@ -123,16 +122,13 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
-          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
-          # re-created from the cached archive in under a minute; caching it as well blew the
-          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
-          gradle-home-cache-excludes: |
-            caches/*/transforms
           # Read-only: this job resolves the build's dependencies plus the test classpath, so its
           # bundle hashes differently from the build job's and the enhanced cache provider stores it
           # as a second whole entry - 1920 MB against the build job's 1743 MB, for maybe 180 MB of
           # dependencies the build job does not have. `needs: [ build ]` means the build job has
           # already written its entry, so this one restores that and re-resolves the difference.
+          # Worth keeping now that the budget is 25 GB: not saving also means not compressing and
+          # uploading ~1.9 GB at the end of every run.
           cache-read-only: true
 
       # Run tests
@@ -191,11 +187,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
-          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
-          # re-created from the cached archive in under a minute; caching it as well blew the
-          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
-          gradle-home-cache-excludes: |
-            caches/*/transforms
           # Read-only, for the same reason as the test job: this job resolves the integrationTest
           # classpath on top of everything else, so its bundle was stored as a third whole entry -
           # 2101 MB, the largest of the three - for roughly 360 MB the build job does not have.
@@ -257,11 +248,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
-          # The extracted IntelliJ platform (caches/<gradle>/transforms) is ~1.4 GB per job and is
-          # re-created from the cached archive in under a minute; caching it as well blew the
-          # repository's 10 GB cache budget and evicted everything, so every run downloaded anyway.
-          gradle-home-cache-excludes: |
-            caches/*/transforms
           # Read-only: restoring another job's entry gives this one the platform and dependencies.
           # The verifier IDEs are cached separately below rather than through this entry, which
           # would also duplicate the ~2 GB dependency set the build and test jobs already keep.
@@ -274,8 +260,8 @@ jobs:
       # pluginVerification selects RELEASE channels only (EAP is deliberately absent - see
       # build.gradle.kts), so the set turns over when JetBrains ships a patch release, not with
       # every EAP build. The key therefore rotates monthly on top of gradle.properties, which is
-      # what decides the window: one live entry of ~2.4 GB most of the time, two briefly at a
-      # rollover, against a 10 GB repository budget.
+      # what decides the window: one live entry - 3179 MB as measured, not the ~2.4 GB the old
+      # comment here guessed - and two briefly at a rollover.
       - name: Verifier IDE cache key
         id: verifier-ides-key
         run: echo "month=$(date -u +%Y-%m)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,8 +37,8 @@ jobs:
 
       # The manual build below resolves the IntelliJ platform (~2 GB). Without this the CodeQL job
       # downloads it from scratch on every run, since it is the one workflow here that builds
-      # without setting Gradle up. Read-only: build.yml populates these entries, and this job must
-      # not add a third copy to the repository's 10 GB cache budget.
+      # without setting Gradle up. Read-only: build.yml populates these entries, and this job has no
+      # reason to write another copy of them.
       - name: Setup Gradle
         if: matrix.language == 'java-kotlin'
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -3,9 +3,8 @@
 # This replaces the repository's "Automatic dependency submission" setting (Settings -> Code
 # security), which runs the same action through a workflow we cannot configure: it sets up its own
 # temurin JDK and writes its own Gradle cache entry, a second full copy of the dependency set
-# (~3.3 GB) scoped to whatever branch it ran on. Two open dependabot PRs were enough to push the
-# repository past its 10 GB cache budget and evict everything - the same failure the
-# gradle-home-cache-excludes in build.yml exists to avoid.
+# (~3.3 GB) scoped to whatever branch it ran on, where nothing else could ever restore it. Two open
+# dependabot PRs were enough to push the repository past its cache budget and evict everything.
 #
 # Running it here, on main only and with the cache read-only, submits the same graph and writes
 # nothing to the cache.
@@ -47,5 +46,3 @@ jobs:
           cache-read-only: true
           # Skip the artifact upload; the snapshot goes straight to the API.
           dependency-graph: generate-and-submit
-          gradle-home-cache-excludes: |
-            caches/*/transforms

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -1,17 +1,20 @@
-# Deletes superseded Actions cache entries, so the repository stays under its 10 GB budget without
-# GitHub having to LRU-evict for us.
+# Deletes superseded Actions cache entries, so storage tracks what the builds actually use.
 #
-# GitHub already expires entries unused for 7 days and evicts by least-recently-used once the
-# budget is exceeded, but LRU is blind: when this repository last went over, it evicted the 1.7 GB
-# IDE Starter archive and live dependency bundles indiscriminately and every job re-downloaded.
-# This prunes the entries that are actually dead instead.
+# Two settings shape this. The budget is 25 GB, raised from the default 10 GB - a repository admin
+# can go to 10 TB for a user-owned repository, at $0.07/GB/month on storage above 10 GB, billed on
+# what is used rather than on the ceiling, so the headroom itself is free. Retention is 30 days,
+# raised from the default 7.
 #
-# The 10 GB budget is the default, not a hard ceiling: a repository admin can raise it (up to 10 TB
-# for a user-owned repository) for $0.07/GB/month on storage above 10 GB, billed on what is used
-# rather than on the ceiling. Raising it is the cheaper fix if this workflow ever stops keeping up.
+# Longer retention is why this workflow earns its place. GitHub now holds a dead entry for a month
+# rather than a week, so nothing gets collected for us: every dependency bump leaves a ~1.7 GB
+# bundle behind, and the verifier IDE cache leaves a ~3.2 GB one at each monthly rollover. The
+# budget is large enough to absorb that, but there is no reason to pay for a month of entries no
+# build will read. The alternative - letting usage climb until GitHub evicts by
+# least-recently-used - is what this repository already tried: LRU is blind, and it took the 1.7 GB
+# IDE Starter archive and live dependency bundles with it while every job re-downloaded.
 #
 # What counts as dead: an entry that is not the most recent of its family and has not been read for
-# two days.
+# seven days.
 #
 # The read rule has a blind spot worth knowing. It can only reclaim an entry that jobs have stopped
 # restoring, and a job goes on restoring its own job-id lineage even after it is made
@@ -21,8 +24,8 @@
 # the shape to look for: a large entry with a recent last-read that no longer needs to exist. A "family" is the key with its trailing content hash - and any -YYYY-MM stamp - removed,
 # so `gradle-dependencies-v2-<hash>` entries form one family and `verifier-ides-<os>-<hash>-<month>`
 # another. The newest member of every family is never deleted, whatever its age, so a prune can
-# never cost a job its cache; superseded members drop out two days after the last run that read
-# them, rather than the seven GitHub allows.
+# never cost a job its cache; superseded members drop out a week after the last run that read them,
+# rather than the thirty days this repository's retention setting allows.
 name: Prune caches
 
 on:
@@ -54,7 +57,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
-          KEEP_UNREAD_SECONDS: '172800' # two days
+          KEEP_UNREAD_SECONDS: '604800' # seven days
         run: |
           set -euo pipefail
 

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -6,8 +6,19 @@
 # IDE Starter archive and live dependency bundles indiscriminately and every job re-downloaded.
 # This prunes the entries that are actually dead instead.
 #
+# The 10 GB budget is the default, not a hard ceiling: a repository admin can raise it (up to 10 TB
+# for a user-owned repository) for $0.07/GB/month on storage above 10 GB, billed on what is used
+# rather than on the ceiling. Raising it is the cheaper fix if this workflow ever stops keeping up.
+#
 # What counts as dead: an entry that is not the most recent of its family and has not been read for
-# two days. A "family" is the key with its trailing content hash - and any -YYYY-MM stamp - removed,
+# two days.
+#
+# The read rule has a blind spot worth knowing. It can only reclaim an entry that jobs have stopped
+# restoring, and a job goes on restoring its own job-id lineage even after it is made
+# cache-read-only - so `test`'s and `integration-test`'s bundles kept being read every run, stayed
+# fresh, and were never eligible here. They had to be deleted by hand once; from then on those jobs
+# fall back to the build job's entry. If usage creeps up with nothing selected for pruning, that is
+# the shape to look for: a large entry with a recent last-read that no longer needs to exist. A "family" is the key with its trailing content hash - and any -YYYY-MM stamp - removed,
 # so `gradle-dependencies-v2-<hash>` entries form one family and `verifier-ides-<os>-<hash>-<month>`
 # another. The newest member of every family is never deleted, whatever its age, so a prune can
 # never cost a job its cache; superseded members drop out two days after the last run that read


### PR DESCRIPTION
Two commits. The first records what the prune rule cannot reclaim; the second spends the raised budget and removes the stale rationale now that it is 25 GB with 30-day retention rather than 10 GB with 7.

## What the prune rule cannot reclaim

The unread rule only reaches entries that jobs have **stopped restoring** — and a job keeps restoring its own job-id lineage even after it is made `cache-read-only`. Evidence from run `34001735023`: `test`'s 1920 MB bundle, created 00:16, was last read at **00:39** by that run, well after #361 made the job read-only.

So the ~4 GB #361 was meant to give back was never going to arrive on its own; those entries would have sat there being read every run, permanently fresh and permanently ineligible. They needed one manual delete, after which the read-only jobs fall back to the build job's entry. Usage went 9.18 GB → **5.29 GB**. The symptom to recognise: usage that will not come down while a prune run reports nothing to do.

## Spending the budget

**Transforms are cached again.** This was the one compromise made purely for space. The extracted IntelliJ platform is ~1.4 GB and its own comment put re-extraction at "under a minute" — paid on all four jobs of every run. With the build job now the only writer it is cached once and the read-only jobs restore it, so that minute comes back four times per run for 1.4 GB of a budget with 20 GB spare.

The exclusion is dropped from the three read-only jobs and from dependency submission too, where it never did anything: `gradle-home-cache-excludes` filters what gets **saved**, and those jobs do not save.

**`cache-read-only` stays** on test, integration-test and verify. It was introduced to save space, but not saving also means not compressing and uploading ~1.9 GB at the end of every run — so it pays for itself in time now that space is not the argument.

**The prune cutoff goes from two days to seven.** Longer retention makes this workflow matter *more*, not less: GitHub now holds a dead entry for a month rather than a week, so nothing is collected for us, and every dependency bump leaves a ~1.7 GB bundle behind while the verifier IDE cache leaves a ~3.2 GB one at each monthly rollover. Two days was chosen under pressure; a week is still four times tighter than retention.

**Eleven "10 GB budget" references removed** across `build.yml`, `codeql.yml`, `dependency-submission.yml` and `prune-caches.yml`. They were the stated justification for the transforms exclusion, three `cache-read-only` flags and this whole workflow, and all of them now cited a number that no longer applies.

One number was also wrong independently of the budget change: the verifier IDE entry was described as "~2.4 GB", carried over from a stale comment. Measured, it is 3179 MB.

## Verification

- All four workflows parse, and the parsed `with:` blocks are as intended — `build` has no inputs, the other three have `cache-read-only: true` and no excludes. (The first pass left `build` with a `with:` containing only comments, which parses as `with: null`; the comment was moved above the step instead.)
- The prune selection re-run against the live cache list with the seven-day cutoff still selects **0 entries** — correct, everything there was read today.