### PR TITLE
Submit only the dependencies that ship, not every configuration

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -46,3 +46,16 @@ jobs:
           cache-read-only: true
           # Skip the artifact upload; the snapshot goes straight to the API.
           dependency-graph: generate-and-submit
+          # Submit only what ships. The action resolves every configuration in the build, and most
+          # of them describe things a user never receives: compileClasspath carries the IntelliJ
+          # platform, and KarateTestRunner declares karate-junit5 as compileOnly *without* the
+          # `isTransitive = false` the root project uses, so resolving it pulls karate-core and with
+          # it armeria, netty, thymeleaf, json-smart and httpclient. That tree alone was 85 open
+          # Dependabot alerts against libraries the plugin does not contain - the plugin ships the
+          # two karate jars and nothing beneath them.
+          #
+          # runtimeClasspath is what prepareSandbox bundles, so it keeps real exposure visible - a
+          # CVE in the bundled karate jars, or in logback - while dropping compile-only and test
+          # configurations. Anchored so it does not also match testRuntimeClasspath and
+          # integrationTestRuntimeClasspath.
+          dependency-graph-include-configurations: '^runtimeClasspath$'


### PR DESCRIPTION
Stacked on #362 (both touch `dependency-submission.yml`); retargets to `main` when that merges.

**All 85 open Dependabot alerts are against libraries the plugin does not contain.**

## Why they exist

The submission resolves *every* configuration in the build. The root project pins both Karate dependencies non-transitively:

```kotlin
implementation("io.karatelabs:karate-junit5:$karateVersion") { isTransitive = false }
implementation("io.karatelabs:karate-core:$karateVersion")   { isTransitive = false }
```

but `KarateTestRunner/build.gradle.kts:11` does not:

```kotlin
compileOnly("io.karatelabs:karate-junit5:$karateVersion")
```

So resolving that subproject's `compileClasspath` pulls `karate-core` and, beneath it, **armeria** — which is where the ~40 netty alerts come from — plus thymeleaf, json-smart, httpclient and the rest of Karate's POM. It's `compileOnly`, so none of it is bundled: the plugin ships `karate-core.jar` and `karate-junit5.jar` and nothing under them.

Two independent signs the graph was describing something that never existed:

- **726 packages** for a project declaring roughly a dozen.
- `io.netty:netty-codec-http` present at **both** `4.1.115.Final` and `4.2.15.Final` — no single resolved classpath can contain two versions of one library.

Every alert is attributed to `settings.gradle.kts`, which is the synthetic manifest a submitted snapshot reports under — confirming these came from the snapshot rather than from GitHub parsing the build files.

## The change

```yaml
dependency-graph-include-configurations: '^runtimeClasspath$'
```

`runtimeClasspath` is what `prepareSandbox` bundles, so this submits what a user actually receives. It keeps real exposure visible — a CVE in the bundled Karate jars, or in logback, still alerts — while dropping compile-only and test configurations. The pattern is anchored so it doesn't also match `testRuntimeClasspath` or `integrationTestRuntimeClasspath`.

## Worth noting

This is only fixable because #358 moved dependency submission into a workflow we control. GitHub's Automatic dependency submission setting runs the same action with no way to pass this input.

## What to expect

Alerts don't clear on merge — they clear after the next `Dependency Submission` run on `main` rebuilds the graph, at which point packages no longer present get auto-dismissed as no longer detected. The number to sanity-check afterwards is *low but not necessarily zero*: anything genuinely bundled should still be reported. If it goes to exactly zero, the filter is too narrow and `runtimeClasspath` isn't resolving what I think it is.