### PR TITLE
Bundle Karate 1.5.2, and name both versions when the fallback runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
 - Running a feature that isn't inside any module - a project opened from its `pom.xml` rather than imported, or a symlinked project path - now says so up front, instead of launching a JVM with no classpath and failing with "Must have karate-core on the classpath"
 - Security vulnerabilities and library updates
 
+### Modified
+
+- The bundled Karate 1 fallback runner is now **1.5.2**, the last 1.x release. It is used only when a module has Karate on its classpath but no `karate-junit5`, and the console warning about it now names both versions - the bundled one and the Karate your module actually has - so a mismatch is something you can see rather than infer. Karate's own step keywords and match markers are unchanged between 1.5.1 and 1.5.2.
+
 ## [2.5.2] - 2026-03-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Key version properties are in `gradle.properties`:
 - `pluginVersion` - Current plugin version (SemVer)
 - `platformVersion` - Target IntelliJ platform version
 - `pluginSinceBuild` - Minimum supported build. There is deliberately no `until-build` (see the `ideaVersion` block in `build.gradle.kts`)
-- `karateVersion` - Karate 1.x version bundled as the v1 fallback runner (1.5.1). Karate 2 is never bundled; the v2 path reflects on whatever `karate-core` 2.x the user's module has
+- `karateVersion` - Karate 1.x version bundled as the v1 fallback runner (1.5.2, the last 1.x release). Karate 2 is never bundled; the v2 path reflects on whatever `karate-core` 2.x the user's module has
 - `logbackVersion` - logback used by the plugin itself
 
 Dependency versions are managed in `gradle/libs.versions.toml`.
@@ -267,7 +267,7 @@ Key dependencies (see `gradle/libs.versions.toml` and `gradle.properties`):
 | Dependency | Version | Purpose |
 |-----------|---------|---------|
 | IntelliJ Platform | `platformVersion` in `gradle.properties` (Ultimate) | IDE platform APIs |
-| Karate Core / JUnit 5 | `karateVersion` (1.5.1) | Bundled v1 fallback runner |
+| Karate Core / JUnit 5 | `karateVersion` (1.5.2) | Bundled v1 fallback runner |
 | Logback | `logbackVersion` | Logging |
 | Kodein DI | `libs.versions.toml` | Dependency injection (integration tests) |
 | JUnit Jupiter / Platform, JUnit 4, Mockito, Kotlin, GrammarKit | `gradle/libs.versions.toml` | Testing, integration-test language, build |

--- a/KarateTestRunner/build.gradle.kts
+++ b/KarateTestRunner/build.gradle.kts
@@ -8,7 +8,17 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.karatelabs:karate-junit5:${properties("karateVersion").get()}")
+    // Pinned non-transitively, as the root project pins them: this module compiles against
+    // FeatureRuntime and ScenarioCall and reflects on RuntimeHook, all of which come from
+    // karate-core, and takes none of karate's own tree. Resolving it transitively pulled armeria,
+    // netty, thymeleaf and the rest onto a compileOnly classpath that ships nothing, which is what
+    // the submitted dependency graph was reporting to Dependabot.
+    compileOnly("io.karatelabs:karate-junit5:${properties("karateVersion").get()}") {
+        isTransitive = false
+    }
+    compileOnly("io.karatelabs:karate-core:${properties("karateVersion").get()}") {
+        isTransitive = false
+    }
     implementation("ch.qos.logback:logback-classic:${properties("logbackVersion").get()}")
 }
 

--- a/KarateTestRunner/src/main/java/com/rankweis/uppercut/testrunner/KarateTestRunner.java
+++ b/KarateTestRunner/src/main/java/com/rankweis/uppercut/testrunner/KarateTestRunner.java
@@ -78,6 +78,31 @@ public class KarateTestRunner {
     mParallel.invoke(invoke, parallelism);
   }
 
+  /**
+   * Names the two Karate versions in play, when the plugin could work them out from the jar names.
+   * "May be inconsistent" is only actionable if the reader can see which Karate ran against which,
+   * and unversioned or shaded jars mean either half can be missing.
+   */
+  String providedKarateVersions() {
+    String bundled = firstParam("karate-bundled-version");
+    String module = firstParam("karate-module-version");
+    if (bundled == null && module == null) {
+      return "";
+    }
+    if (module == null) {
+      return " (karate-junit5 " + bundled + ")";
+    }
+    if (bundled == null) {
+      return " (against karate " + module + " on your classpath)";
+    }
+    return " (karate-junit5 " + bundled + " against karate " + module + " on your classpath)";
+  }
+
+  private String firstParam(String key) {
+    List<String> values = params.get(key);
+    return values == null || values.isEmpty() ? null : values.get(0);
+  }
+
   Object createRuntimeHook() {
     Logger myLogger = LoggerFactory.getLogger(KarateTestRunner.class);
     // Load the RuntimeHook class using reflection
@@ -86,9 +111,10 @@ public class KarateTestRunner {
         .stream().anyMatch(Boolean::parseBoolean);
     if (uppercutProvidedKarate) {
       myLogger.error(
-        "Uppercut could not find a version of karate-junit5 in the classpath. It is using a provided one - this can "
-          + "cause inconsistent results or errors. For the best experience, please include karate-junit5 in your "
-          + "project");
+        "Uppercut could not find a version of karate-junit5 in the classpath. It is using a provided one"
+          + providedKarateVersions()
+          + " - this can cause inconsistent results or errors. For the best experience, please include "
+          + "karate-junit5 in your project");
     }
     Class<?> runtimeHookClass;
     try {

--- a/docs/risks/karate-v1-regressions.md
+++ b/docs/risks/karate-v1-regressions.md
@@ -13,7 +13,7 @@ Baseline for "before": `main` prior to the Karate 2 work. The v1 execution path 
 
 | # | Risk | Mechanism | Guard | Status |
 |---|------|-----------|-------|--------|
-| R1 | Bundled-karate fallback fires on working v1 setups | Detection moved from a project-wide library scan to the run module's classpath. Karate jars attached to a sibling module (root-module run configs, shared test-support modules) become invisible, `--karate-provided` injects bundled karate-junit5 1.5.1 over the user's real Karate version | Module scan is only authoritative when the module has a `karate-*` jar; otherwise detection widens back to the project-wide scan (`moduleScanIsAuthoritative`). Unit-tested | **Mitigated** |
+| R1 | Bundled-karate fallback fires on working v1 setups | Detection moved from a project-wide library scan to the run module's classpath. Karate jars attached to a sibling module (root-module run configs, shared test-support modules) become invisible, `--karate-provided` injects bundled karate-junit5 1.5.2 over the user's real Karate version | Module scan is only authoritative when the module has a `karate-*` jar; otherwise detection widens back to the project-wide scan (`moduleScanIsAuthoritative`). Unit-tested | **Mitigated** |
 | R2 | AUTO misclassifies a v1 module as v2 | Any jar matching `karate-(core|junit6)-2\..*` in the module's *recursive* dependencies flips the run to the v2 runner, which then dies on a v1 classpath (`ClassNotFoundException: io.karatelabs.core.Runner`). A stale transitive karate-core 2.x anywhere in the tree is enough | None beyond the regex being name-anchored. The settings override (V1) is the escape hatch: with both majors on the classpath the pin wins, and the mismatch guard only refuses a pin that cannot work (V1 with no Karate 1 jar at all). Unit-tested | **Accepted** — needs a real-world report to justify more machinery |
 | R3 | v1 console pipeline hangs off one reflective call | The `<<UPPERCUT>>` appender is now installed via `Class.forName("...UppercutLogbackAppender")` with a blanket `catch (Throwable)`. If that class ever fails to load for a packaging reason (jar split, shading), every v1 run silently degrades to an empty tree, because all three converter regexes only match prefixed lines | The v1 leg of `Karate2UITest` runs the real packaged plugin and asserts the tree — a packaging break fails CI. The catch prints one stderr line naming the cause | **Guarded by test** |
 | R4 | Version override contradicts the classpath | Pinning V1 with only Karate 2 jars (or V2 with none) used to die deep in the wrong runner with an unrelated-looking `NoSuchMethodException` after silently injecting the bundled v1 jar | `checkVersionOverrideMatchesClasspath` refuses the run up front, naming the setting. AUTO never hits it. Unit- and UI-tested | **Mitigated** |
@@ -32,7 +32,7 @@ Reasoning for things deliberately *not* done, so they don't get re-argued from s
 ### The bundled-Karate fallback stays v1-only (decided 2026-07-20)
 
 On the v1 path, a project with no `karate-junit5` gets the plugin's own bundled copy injected
-(`--karate-provided`, `karate-junit5` 1.5.1). Karate 2 has no equivalent and will not get one.
+(`--karate-provided`, `karate-junit5` 1.5.2). Karate 2 has no equivalent and will not get one.
 
 - **The gap it covers does not exist on v2.** It was built for Karate 1 users who had `karate-core`
   without the JUnit 5 artifact. `karate-junit6` brings `karate-core` with it, so there is no split
@@ -52,7 +52,7 @@ JUnit artifact.
 ## Standing invariants (break one of these and v1 users notice)
 
 - The v1 branch of `KarateTestRunner.main` and everything it calls (`doTest`, `createRuntimeHook`,
-  caller-chain reflection) must keep working against karate-core **1.5.1** — that exact jar ships
+  caller-chain reflection) must keep working against karate-core **1.5.2** — that exact jar ships
   inside the plugin as the bundled fallback.
 - The `<<UPPERCUT>>` prefix format written by `UppercutLogbackAppender` is load-bearing: the
   converter's `UPPERCUT_LOG_PATTERN`, `SCENARIO_NAME`, and `FEATURE_FILE_NAME` regexes parse it.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginName = Uppercut for Karate
 pluginRepositoryUrl = https://github.com/rankweis/uppercut
 # SemVer format -> https://semver.org
 pluginVersion = 3.0.1
-karateVersion = 1.5.1
+karateVersion = 1.5.2
 logbackVersion = 1.5.38
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -71,7 +71,7 @@ Either way, a `call read('classpath:...')` inside a feature fails for exactly th
 
 ## A step shows "Uppercut could not find a version of karate-junit5 in the classpath. It is using a provided one"
 
-Karate 1 only. The module has `karate-core` but not `karate-junit5`, so the plugin ran the tests with its own bundled copy of Karate 1.5.1. Results are usually right, but you're testing against a different Karate than your build declares - add `karate-junit5` to the module to run with yours. There is no bundled Karate 2; `karate-junit6` brings `karate-core` with it.
+Karate 1 only. The module has `karate-core` but not `karate-junit5`, so the plugin ran the tests with its own bundled copy of Karate 1.5.2 - the last 1.x release. Results are usually right, but you're testing against a different Karate than your build declares - add `karate-junit5` to the module to run with yours. There is no bundled Karate 2; `karate-junit6` brings `karate-core` with it.
 
 ## JavaScript in a feature is flagged as invalid, but Karate runs it
 

--- a/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java
+++ b/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java
@@ -40,7 +40,10 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -155,7 +158,19 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
             log.warn("No junit5 in classpath");
             // The bundled fallback is v1-only; v2 users always have karate on their own classpath.
             params.getProgramParametersList().add("--karate-provided", "true");
-            params.getClassPath().add(PathUtil.getJarPathForClass(Karate.class));
+            String bundledJar = PathUtil.getJarPathForClass(Karate.class);
+            params.getClassPath().add(bundledJar);
+            // Both versions, so the warning the runner prints can name them. "Results may be
+            // inconsistent" is only actionable if the user can see which Karate ran against which.
+            String bundledVersion = karateJarVersion(new File(bundledJar).getName());
+            if (bundledVersion != null) {
+              params.getProgramParametersList().add("--karate-bundled-version", bundledVersion);
+            }
+            libraryNames.stream()
+              .map(KarateRunConfiguration::karateJarVersion)
+              .filter(Objects::nonNull)
+              .findFirst()
+              .ifPresent(v -> params.getProgramParametersList().add("--karate-module-version", v));
           }
         }
         params.setUseDynamicClasspath(true);
@@ -382,6 +397,19 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
   static boolean isKarate2Jar(String name) {
     return name.matches("karate-(core|junit6)-2\\..*") || name.matches("karate-junit6(-.*)?\\.jar");
   }
+
+  /**
+   * The version in a Karate jar's file name, or null when the name carries none. Local or shaded
+   * jars are often unversioned ({@code karate-core.jar}), which is why the caller treats a null as
+   * "say nothing" rather than as a mismatch.
+   */
+  static @Nullable String karateJarVersion(String jarName) {
+    Matcher matcher = KARATE_JAR_VERSION.matcher(jarName);
+    return matcher.matches() ? matcher.group(1) : null;
+  }
+
+  private static final Pattern KARATE_JAR_VERSION =
+    Pattern.compile("karate-(?:core|junit5|junit6)-(\\d+\\.\\d+(?:\\.\\d+)?(?:[.-][A-Za-z0-9]+)*)\\.jar");
 
   /** karate-core/karate-junit5 1.x, or a karate-junit5 jar of any version - that artifact only exists in v1. */
   static boolean isKarate1Jar(String name) {

--- a/src/test/java/com/rankweis/uppercut/karate/run/KarateVersionDetectionTest.java
+++ b/src/test/java/com/rankweis/uppercut/karate/run/KarateVersionDetectionTest.java
@@ -1,5 +1,6 @@
 package com.rankweis.uppercut.karate.run;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -105,6 +106,24 @@ public class KarateVersionDetectionTest {
     assertTrue(noModule, noModule.contains("not inside any module"));
     String noKarate = KarateRunConfiguration.classpathProblem(List.of("junit-jupiter-5.11.4.jar"), "app.test");
     assertTrue(noKarate, noKarate.contains("'app.test'") && noKarate.contains("karate-junit6"));
+  }
+
+  @Test
+  public void karateJarVersionReadsTheVersionFromTheFileName() {
+    assertEquals("1.5.1", KarateRunConfiguration.karateJarVersion("karate-core-1.5.1.jar"));
+    assertEquals("1.5.1", KarateRunConfiguration.karateJarVersion("karate-junit5-1.5.1.jar"));
+    assertEquals("2.1.1", KarateRunConfiguration.karateJarVersion("karate-junit6-2.1.1.jar"));
+    assertEquals("1.4.0-RC2", KarateRunConfiguration.karateJarVersion("karate-core-1.4.0-RC2.jar"));
+  }
+
+  @Test
+  public void karateJarVersionIsNullWhenTheNameCarriesNone() {
+    // Unversioned and shaded jars are common enough that the caller says nothing rather than
+    // reporting a mismatch it cannot actually see.
+    assertNull(KarateRunConfiguration.karateJarVersion("karate-core.jar"));
+    assertNull(KarateRunConfiguration.karateJarVersion("karate-gatling-2-utils.jar"));
+    assertNull(KarateRunConfiguration.karateJarVersion("my-karate-junit6-2-helper.jar"));
+    assertNull(KarateRunConfiguration.karateJarVersion("junit-jupiter-5.11.4.jar"));
   }
 
   @Test


### PR DESCRIPTION
1.5.2 is the last 1.x release, so the bundled v1 fallback can sit on it and the docs can name it without going stale.

## Parity check

`karateVersion` changed, so I ran the parity check and diffed the jars rather than trusting release notes.

| Surface | 1.5.1 → 1.5.2 |
|---|---|
| Step-action keywords (`ScenarioActions`) | one new method, **not a keyword** |
| Match markers (`Match$Type`) | identical, 16 |
| `RuntimeHook` / `FeatureRuntime` / `ScenarioCall` / `Runner` | identical |

The new method is `evalAssignDocString`, carrying the regex `^([\w]+\.[^=]+=$)` — the doc-string form of assigning to a dotted path, joining `defDocString`, `yamlDocString`, `csvDocString` and the rest of that family. It introduces no keyword, so `i18n.json` and `PlainKarateKeywordProvider` need nothing.

Worth recording: **1.5.2 is not purely a bugfix release.** It adds a `MatchOperator` interface plus `Match$CoreOperatorFactory`, `Match$MatchOperatorFactory`, `Match$Validator` and `Match$RegexValidator` — a pluggable match-operator mechanism. `Match$Type` survives unchanged beside it and none of it sits on the v1 runner's reflection path, so it doesn't reach us.

## Naming the versions in the fallback warning

The fallback fires only when a module has some `karate-*` jar but no `karate-junit5` — `classpathProblem` refuses the run before it when there's no Karate at all. Its warning already reached the console, but said results "can be inconsistent" without saying between what:

```
Uppercut could not find a version of karate-junit5 in the classpath. It is using a
provided one (karate-junit5 1.5.2 against karate 1.4.0 on your classpath) - this can
cause inconsistent results or errors. ...
```

Both versions are read from jar file names and passed to the runner. A jar whose name carries no version — shaded, or a local build — omits that half rather than reporting a mismatch it can't actually see. Four unit tests cover the extraction, including the unversioned and near-miss names (`karate-gatling-2-utils.jar`, `my-karate-junit6-2-helper.jar`).

## Non-transitive pin in KarateTestRunner

The subproject now pins its Karate dependencies `isTransitive = false`, as the root project already did. `karate-core` has to be named explicitly, since the module compiles against `FeatureRuntime` and `ScenarioCall`.

Resolving `karate-junit5` transitively pulled armeria — hence netty — plus thymeleaf, json-smart and httpclient onto a `compileOnly` classpath that ships nothing. That's what the submitted dependency graph had been reporting to Dependabot; #363 stopped it being *reported*, this stops it being *resolved*.

## Also updated

`gradle.properties`, `site/troubleshooting.md`, `CLAUDE.md` and `docs/risks/karate-v1-regressions.md` all named 1.5.1; the troubleshooting page and CLAUDE.md now say 1.5.2 and note it's the last 1.x. Changelog entry added.

## Verification

`./gradlew test checkstyleMain checkstyleTest` — BUILD SUCCESSFUL, **95 tests, 0 failures**, no checkstyle violations. Both modules compile against 1.5.2.