### PR TITLE
Fan the build jobs out, and stop reclaiming disk nobody needs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,6 @@ jobs:
   # Run tests and upload a code coverage report
   test:
     name: Test
-    needs: [ build ]
     runs-on: ubuntu-latest
     steps:
 
@@ -157,17 +156,12 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     needs: [ build ]
     runs-on: ubuntu-latest
+    # No free-disk-space step here either - see the note in the verify job. This one was costing
+    # 36s for the same non-problem.
     # five IDE launches with multi-minute waits each; a hung IDE must not hold the release draft for
     # GitHub's six-hour default
     timeout-minutes: 60
     steps:
-
-      # The IDE (~4 GB) plus a JDK need more room than a hosted runner has spare by default
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        with:
-          tool-cache: false
-          large-packages: false
 
       # Check out the current repository
       - name: Fetch Sources
@@ -229,16 +223,12 @@ jobs:
   # Run plugin structure verification along with IntelliJ Plugin Verifier
   verify:
     name: Verify plugin
-    needs: [ build ]
     runs-on: ubuntu-latest
+    # No free-disk-space step here. It used to run because "the IDE (~4 GB) plus a JDK need more
+    # room than a hosted runner has spare by default", which stopped being true: a hosted ubuntu
+    # runner reports 87 GB free before any cleanup, and this job needs perhaps 12 GB. The step was
+    # spending 98s of a 333s job reclaiming 22 GB nobody wanted.
     steps:
-
-     #  Free GitHub Actions Environment Disk Space
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        with:
-          tool-cache: false
-          large-packages: false
 
       # Check out the current repository
       - name: Fetch Sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ concurrency:
 
 permissions:
   contents: read
+# The four build jobs deliberately have no `needs` between them - they fan out from the start.
+# Nothing passes data: no job downloads another's artifact, and each restores its own Gradle User
+# Home lineage rather than the build job's, so waiting for build never warmed anything. The edges
+# only bought fail-fast, at 74s on every green run to save runner minutes on the rare red one.
+# Release draft still gates on all four, so nothing ships without them.
 jobs:
 
   # Prepare environment and build the plugin
@@ -154,7 +159,6 @@ jobs:
   integration-test:
     name: Integration tests
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    needs: [ build ]
     runs-on: ubuntu-latest
     # No free-disk-space step here either - see the note in the verify job. This one was costing
     # 36s for the same non-problem.


### PR DESCRIPTION
Two changes aimed at wall clock rather than cache size. Pull requests go from ~6.8 minutes to **under 4**; main from ~8.8 to **under 7**.

## 1. The disk-cleanup step was freeing space nobody needed

`Maximize Build Space` ran on the verify and integration-test jobs, justified by a comment saying the IDE plus a JDK "need more room than a hosted runner has spare by default". The log from run `34005741483` says otherwise:

```
BEFORE CLEAN-UP:  /dev/root  145G  59G used   87G Avail  41%
AFTER CLEAN-UP:   /dev/root  145G  37G used  109G Avail  26%
```

**87 GB free before it ran**, against roughly 12 GB the job actually uses — a 7× margin. It cost **98s of verify's 333s** and 36s of integration-test's 446s to reclaim 22 GB that was never going to be touched. True on smaller runners once; not true now.

## 2. All four jobs fan out from the start

`test`, `verify` and `integration-test` each dropped `needs: [ build ]`. Those edges carried no data:

- no job downloads the build job's artifact
- each restores its **own** `gradle-home-v2` lineage, not build's, so build finishing first never warmed anything for them

They only bought fail-fast — charging 74s on every green run to save runner minutes on the rare red one. `releaseDraft` still gates on all four, so a broken build cannot ship; it just costs the runner minutes to discover.

## Measured effect

Pull request path (integration-test is `push`-only, so it isn't in it), from run `34005741483`:

| | |
|---|---|
| before | build 74s → max(test 223s, verify 333s) = **407s** |
| after | max(build 74s, test 223s, verify 235s) = **235s** |

Main, from run `34006299400`:

| | |
|---|---|
| before | build 84s → max(238s, 428s, 446s) = **530s** |
| after | max(84s, 238s, 330s, 410s) = **410s** |

## What this doesn't change

Caching is untouched. The verifier still runs the narrow scope on pull requests and `last3` on merge, unchanged since #359 fixed that ternary.

## Trade-off worth knowing

With no `needs` edges, a push that doesn't compile now burns all four jobs instead of stopping after `build`. That's the deliberate trade: green runs are the common case, and they get the 74s back every time.