### PR TITLE
Verify against the EAP, and let nothing wait on the result

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,10 @@ jobs:
   # Run plugin structure verification along with IntelliJ Plugin Verifier
   verify:
     name: Verify plugin
+    # Push only, and nothing waits on it. It checks the plugin against the newest release and the
+    # newest EAP; an EAP failure is information about a platform still in flux, not a reason to
+    # stop a release. Release draft deliberately does not list it in `needs`.
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     # No free-disk-space step here. It used to run because "the IDE (~4 GB) plus a JDK need more
     # room than a hosted runner has spare by default", which stopped being true: a hosted ubuntu
@@ -264,15 +268,10 @@ jobs:
       #
       # Before trying this again, measure first: several runs each way, not one.
       - name: Run Plugin Verification tasks
-        # Pull requests verify against the newest release only; a merge to main widens to the
-        # last three majors. See pluginVerification in build.gradle.kts.
-        #
-        # The non-empty value has to sit in the `&&` slot: GitHub treats '' as falsy, so
-        # `event == 'pull_request' && '' || '-P...'` falls through to the '-P...' on both sides and
-        # every run got the wide scope, pull requests included.
-        run: ./gradlew verifyPlugin $SCOPE
-        env:
-          SCOPE: ${{ github.event_name != 'pull_request' && '-PpluginVerifierScope=last3' || '' }}
+        # No scope flag: the default window is the newest release plus the newest EAP. The wider
+        # backward sweep is `-PpluginVerifierScope=last3` or `=all`, run by hand before a release.
+        # See pluginVerification in build.gradle.kts.
+        run: ./gradlew verifyPlugin
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
@@ -288,7 +287,7 @@ jobs:
     name: Release draft
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
-    needs: [ build, test, verify, integration-test ]
+    needs: [ build, test, integration-test ]
     permissions:
       contents: write
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -247,8 +247,8 @@ intellijPlatform {
             // The verifier has no "last N releases" filter, so the window is a rolling sinceBuild:
             // two majors back from platformVersion, floored at the plugin's own since-build
             // because verifying against IDEs the plugin declares incompatible with proves nothing.
-            // EAP is deliberately absent - JetBrains runs the verifier against EAPs and emails the
-            // failures. recommended() stays available by hand for a pre-release sweep:
+            // The default window is the newest release plus the newest EAP - what a user is on
+            // now, and what they will be on next. The wider backward sweep is on demand:
             //
             //   ./gradlew verifyPlugin -PpluginVerifierScope=all
             //
@@ -258,7 +258,12 @@ intellijPlatform {
                 val wide = properties("pluginVerifierScope").orNull == "last3"
                 select {
                     types = listOf(IntelliJPlatformType.IntellijIdeaUltimate)
-                    channels = listOf(ProductRelease.Channel.RELEASE)
+                    // EAP is in because the plugin declares no until-build: it stays installable on
+                    // every future IDE, so a platform change that lands in the next major reaches
+                    // users whether or not anyone checked. That forward break is the one worth
+                    // catching early; verifying against past releases only confirms the since-build
+                    // claim, which has rarely been wrong.
+                    channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
                     // "2026.2" -> "262": the platform's own major build, so the list follows platformVersion
                     sinceBuild = properties("platformVersion").map { v ->
                         val current = v.split('.').let { (year, minor) -> year.takeLast(2) + minor }


### PR DESCRIPTION
Changes what the verifier checks, stops anything depending on the answer, and deletes the custom configuration that was doing neither well.

## The risk being carried was the one not checked

`build.gradle.kts` declares no upper bound:

```kotlin
untilBuild = provider { null }
// No upper bound on purpose: … verifyPlugin (recommended IDEs) and the
// Marketplace verifier are what catch a breaking platform change.
```

so the plugin stays installable on **every future IDE**. A hundred lines down, the verifier was configured `channels = listOf(ProductRelease.Channel.RELEASE)` — EAP explicitly excluded. Those comments contradicted each other: one claimed verifyPlugin guards forward compatibility, the other guaranteed it couldn't.

What it actually checked was the *backward* direction — that `sinceBuild = 261` holds against 261 and 262 releases. That has rarely been wrong, and it was costing 293s of a 298s pull request run.

## The custom block is gone entirely

The verifier's own default is `recommended()`, and reading what that does makes the hand-rolled version hard to justify:

```kotlin
channels.convention(listOf(Channel.RELEASE, Channel.EAP, Channel.RC))
types.convention(extensionProvider.map { listOf(it.productInfo.type) })
sinceBuild.convention(ideaVersionProvider.flatMap { it.sinceBuild })
untilBuild.convention(ideaVersionProvider.flatMap { it.untilBuild })
```

It derives the window from what the plugin **declares** rather than from anything computed in the build file, so it follows `pluginSinceBuild` automatically and needs no maintenance. The block it replaces computed a rolling window with `majorsBack()`, gated it behind `-PpluginVerifierScope`, and excluded the one channel worth watching.

`majorsBack()` and the `pluginVerifierScope` property go too — both existed only to serve that block. **Net −38 lines**, with wider coverage.

## Nothing waits on the result

- `releaseDraft` drops `verify` from its `needs` — a verify failure no longer holds a release.
- The job runs on **push only**, so pull requests don't wait for it either.

An EAP failure is information about a platform still in flux; the API may well return before that IDE ships. It should not block a merge or a release. The signal arrives, and acting on it becomes a decision rather than an automatic gate.

## Effect

| | before | after |
|---|---|---|
| Pull request | max(build 105s, test 169s, verify 293s) = **298s** | max(105s, 169s) ≈ **169s** |
| Time to release draft on main | gated on verify, **358s** | gated on build/test/integration, ≈ **195s** |

Verify itself gets *slower* — it now covers every RELEASE, EAP and RC from since-build up rather than two IDEs. That's the deliberate trade: more coverage on a job nothing waits for.

## ⚠️ Needs a ruleset change to merge

The `PRs & conventional commits` ruleset (id `22363831`) lists **`Verify plugin`** among its required status checks. With the job skipped on pull requests that check never reports, and **every pull request will block forever** — including this one.

`Verify plugin` has to come out of that ruleset's required checks. `Build` and `Test` stay.

## Verification

`./gradlew test checkstyleMain checkstyleTest` — BUILD SUCCESSFUL, 95 tests, 0 failures, no checkstyle violations. Docs updated: `CLAUDE.md` command list and CI description, and `docs/manual-test-checklist.md`, which told the reader to run the deleted flag by hand before a release.