### PR TITLE
Delete the verification window and use the verifier's own default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,9 +268,9 @@ jobs:
       #
       # Before trying this again, measure first: several runs each way, not one.
       - name: Run Plugin Verification tasks
-        # No scope flag: the default window is the newest release plus the newest EAP. The wider
-        # backward sweep is `-PpluginVerifierScope=last3` or `=all`, run by hand before a release.
-        # See pluginVerification in build.gradle.kts.
+        # No flags and no pluginVerification block: the verifier's own default covers every
+        # RELEASE, EAP and RC from the plugin's since-build upward. See the note where that block
+        # used to be, in build.gradle.kts.
         run: ./gradlew verifyPlugin
 
       # Collect Plugin Verifier Result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,10 @@ Uppercut is an IntelliJ IDEA plugin providing comprehensive IDE support for the 
 # Launch IntelliJ with the plugin loaded for manual testing
 ./gradlew runIde
 
-# Verify plugin compatibility against the newest release + newest EAP (what CI runs)
+# Verify plugin compatibility. The verifier's own default: every RELEASE, EAP and RC from the
+# plugin's since-build upward, for this plugin's platform type. Push-only in CI, and nothing
+# waits on it - an EAP failure is a heads-up, not a gate.
 ./gradlew verifyPlugin
-
-# ... against every supported major, since-build up to the newest EAP (before a release)
-./gradlew verifyPlugin -PpluginVerifierScope=all
 
 ```
 
@@ -251,8 +250,8 @@ Triggers on push to `main`/`ij-2024.2` and pull requests. Jobs:
 1. **Build** - Compile and create plugin artifact
 2. **Test** - Run `check` (excluding integration tests) with Kover code coverage
 3. **Integration tests** - `Karate2UITest` under xvfb; only on push, not pull requests
-4. **Verify** - IntelliJ Plugin Verifier against the newest release and newest EAP of the platform major (`pluginVerification` in `build.gradle.kts`; `-PpluginVerifierScope=all` for the full since-build range)
-5. **Release Draft** - Auto-create GitHub release draft (push to main only); gated on all four jobs above, integration tests included
+4. **Verify** - IntelliJ Plugin Verifier on the verifier's default window (RELEASE, EAP and RC from `pluginSinceBuild` upward). Push-only, and **nothing depends on it**: an EAP break is information about a platform still in flux, not a reason to stop a release
+5. **Release Draft** - Auto-create GitHub release draft (push to main only); gated on build, test and integration tests - deliberately not on verify
 
 Caching: the IntelliJ platform and verifier IDEs are Gradle dependencies, cached by `setup-gradle`. The extracted copies (`caches/*/transforms`) are excluded everywhere and the verify job is read-only - the repository has a 10 GB cache budget, and caching the extracted IDEs per job blew past it and evicted everything.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,21 +161,6 @@ java {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 // Configure Gradle IntelliJ Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 
-// Platform majors run YY1, YY2, YY3 then roll to the next year: 261 follows 253. Steps `n`
-// majors back from a build number like "262", used to build a rolling verification window.
-fun majorsBack(build: String, n: Int): String {
-    var year = build.dropLast(1).toInt()
-    var minor = build.takeLast(1).toInt()
-    repeat(n) {
-        minor -= 1
-        if (minor < 1) {
-            minor = 3
-            year -= 1
-        }
-    }
-    return "$year$minor"
-}
-
 intellijPlatform {
     pluginConfiguration {
         // The Marketplace display name. Without this the manifest keeps the <name> baked into
@@ -236,44 +221,18 @@ intellijPlatform {
         channels = providers.gradleProperty("pluginVersion")
             .map { listOf(it.substringAfter("-ch", "").substringBefore('.').ifEmpty { "default" }) }
     }
-    pluginVerification {
-        ides {
-            // Two scopes, picked by what is being verified. A pull request checks the newest
-            // release of the platform major the plugin is built on - one IDE, the cheapest check
-            // that still catches a break the compiler cannot see. A merge to main widens to the
-            // last three majors, so a break against an IDE people are still running is caught
-            // before the release draft is cut rather than after publishing.
-            //
-            // The verifier has no "last N releases" filter, so the window is a rolling sinceBuild:
-            // two majors back from platformVersion, floored at the plugin's own since-build
-            // because verifying against IDEs the plugin declares incompatible with proves nothing.
-            // The default window is the newest release plus the newest EAP - what a user is on
-            // now, and what they will be on next. The wider backward sweep is on demand:
-            //
-            //   ./gradlew verifyPlugin -PpluginVerifierScope=all
-            //
-            if (properties("pluginVerifierScope").orNull == "all") {
-                recommended()
-            } else {
-                val wide = properties("pluginVerifierScope").orNull == "last3"
-                select {
-                    types = listOf(IntelliJPlatformType.IntellijIdeaUltimate)
-                    // EAP is in because the plugin declares no until-build: it stays installable on
-                    // every future IDE, so a platform change that lands in the next major reaches
-                    // users whether or not anyone checked. That forward break is the one worth
-                    // catching early; verifying against past releases only confirms the since-build
-                    // claim, which has rarely been wrong.
-                    channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
-                    // "2026.2" -> "262": the platform's own major build, so the list follows platformVersion
-                    sinceBuild = properties("platformVersion").map { v ->
-                        val current = v.split('.').let { (year, minor) -> year.takeLast(2) + minor }
-                        val start = if (wide) majorsBack(current, 2) else current
-                        maxOf(start, properties("pluginSinceBuild").get())
-                    }
-                }
-            }
-        }
-    }
+    // No pluginVerification block. The default is `recommended()`, which derives the window from
+    // what the plugin itself declares rather than from anything hand-computed here:
+    //
+    //   channels  = RELEASE, EAP, RC
+    //   types     = this plugin's own platform type
+    //   sinceBuild = ideaVersion.sinceBuild  (pluginSinceBuild)
+    //   untilBuild = ideaVersion.untilBuild  (null - see pluginConfiguration below)
+    //
+    // That is the newest release, the newest EAP and any RC, from the plugin's since-build upward,
+    // and it follows pluginSinceBuild automatically. The block that used to sit here computed a
+    // rolling window with majorsBack() and gated it behind -PpluginVerifierScope, and excluded EAP
+    // - the one channel that catches a break in the IDE users are about to upgrade to.
 }
 
 tasks.withType<Copy> {

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -76,9 +76,9 @@ per-module detection. See `Karate2UITest`.
       project. Then install this build over it: settings survive (version pref = AUTO),
       v1 project still runs identically.
 - [ ] plugin.xml compatibility range: verify the build installs on the oldest supported IDE
-      (261) - the UI test pins `platformVersion`, and CI's verifyPlugin only covers the newest
-      release and EAP. `./gradlew verifyPlugin -PpluginVerifierScope=all` covers every major from
-      since-build up; run it before a release.
+      (261) - the UI test pins `platformVersion`. CI's verifyPlugin now covers every RELEASE, EAP
+      and RC from since-build upward by default, so this is a spot-check of the install rather than
+      of the API surface.
 
 ## 7. Environment matrix
 


### PR DESCRIPTION
The second half of #368. That PR merged while GitHub's PR object was still showing only its first commit, so this one never landed — main has the EAP change and the advisory wiring, but still carries the hand-rolled verification window this was meant to replace.

## What the default already does

```kotlin
channels.convention(listOf(Channel.RELEASE, Channel.EAP, Channel.RC))
types.convention(extensionProvider.map { listOf(it.productInfo.type) })
sinceBuild.convention(ideaVersionProvider.flatMap { it.sinceBuild })
untilBuild.convention(ideaVersionProvider.flatMap { it.untilBuild })
```

`recommended()` derives the window from what the plugin **declares** — `pluginSinceBuild` and the deliberately-null `untilBuild` — rather than from anything computed in the build file. It covers every RELEASE, EAP and RC from since-build upward, for this plugin's own platform type, and it follows `pluginSinceBuild` automatically with no maintenance.

The block it replaces computed a rolling window with `majorsBack()`, gated it behind `-PpluginVerifierScope`, and (before #368) excluded EAP entirely.

`majorsBack()` and the `pluginVerifierScope` property go with it — both existed only to serve that block.

## Also updated

Documentation that referenced the deleted flag:

- `CLAUDE.md` — the command list and the CI job description
- `docs/manual-test-checklist.md`, which instructed the reader to run `-PpluginVerifierScope=all` by hand before a release

## Effect

**Net −42 lines**, with wider coverage than before. Verify itself gets slower — every RELEASE, EAP and RC from 261 up rather than a two-IDE window — which is the intended trade now that the job is push-only and nothing waits on it (`releaseDraft` gates on build, test and integration tests only).

## Verification

`./gradlew test checkstyleMain checkstyleTest` — BUILD SUCCESSFUL, 95 tests, 0 failures, no checkstyle violations. Gradle configuration resolves, and no references to `pluginVerifierScope` or `majorsBack` remain outside the historical note explaining the removal.