### PR TITLE
Clean up verifier findings, and add a fix-issues skill

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: fix-issues
+description: Triage open GitHub issues, fix the ones that are real bugs, and open a PR for each without merging. Use on "fix issues", "look at the issues", "work through the bug reports", or when handed an issue number to fix.
+---
+
+# Working through GitHub issues
+
+One issue, one branch, one PR. Never merge, never close an issue directly - a PR that says
+`Fixes #N` closes it when a human merges.
+
+## Pick what to work on
+
+```bash
+gh issue list --state open --limit 30 --json number,title,labels,author,createdAt
+gh issue view <n> --comments
+```
+
+With no issue named, work the oldest unlabelled bug first and stop after one unless told otherwise.
+Fixing several at once produces a PR nobody can review.
+
+## Triage before touching code
+
+Fix only **reproducible defects**. Everything else gets a comment saying what it is and why, and no
+branch:
+
+| Not a fix | What it looks like |
+|---|---|
+| Feature request | "it would be great if", a Karate feature the plugin has never supported, anything on `site/status.md` as "Not planned" |
+| Question or support | a Karate question rather than a plugin one; a broken build or classpath in the reporter's project |
+| Needs a decision | two defensible behaviours and no obvious right one - ask in the issue, do not pick one silently |
+| Not reproducible | say exactly what you tried, including versions, and ask for the missing piece |
+
+A bug report that turns out to be **documented behaviour** is still not a fix: if the docs say it and
+the reporter missed it, the gap is usually the docs, so fix those instead.
+
+## Reproduce first, always
+
+A fix without a reproduction is a guess. In rough order of cost:
+
+1. A **unit test** in `src/test/java` (or `KarateTestRunner/src/test/java`) that fails for the reported
+   reason. Cheapest, and it stays as the regression guard.
+2. The **fixture** at `testProjects/karate-versions` - a v1 and a v2 module. Add a feature file that
+   shows the problem rather than editing `sample/users*.feature`, whose line numbers other tests pin.
+3. The **runner harnesses** for anything about runs or debugging: `:v1:debugHarness`,
+   `:v2:debugHarness`, `:v2:eventProbe`, `:v2:debugProbe`. See `docs/DEBUGGER.md` and the
+   `debug-test-runner` skill.
+4. **`./gradlew runIde`** for anything that only exists on screen - gutter icons, tool windows,
+   dialogs, breakpoints. Ask the user to drive it and tell you what they see; you cannot.
+
+Reproducing in the reporter's Karate version matters: `gradle.properties` pins v1, and v2 is whatever
+`karate-junit6` the module has. Most "it works for me" reports are version differences.
+
+## Fix it the way the repo does
+
+- `CLAUDE.md` has the build commands, the style rules and the architecture. Follow the file you are
+  editing more than any general instinct.
+- Keep the change the size of the bug. A refactor that would help belongs in its own issue.
+- `./gradlew check` must pass. Run `./gradlew integrationTest --tests '*Karate2UITest'` as well when
+  the change touches run configurations, the runner, the debugger or `plugin.xml` - it is the only
+  thing that exercises a real IDE.
+- A user-visible change needs a `CHANGELOG.md` entry (the `changelog` skill) and, when it changes what
+  works or what a message says, the matching page under `site/`.
+- Verify your edits landed. A scripted replace that silently matches nothing is the most common way to
+  "fix" something and ship it unchanged.
+
+## Open the PR
+
+```bash
+git checkout -b <named-after-the-change> origin/main   # never "claude" anywhere in the name
+git commit                                             # no Co-Authored-By or session trailers
+git push -u origin <branch>
+gh pr create --title "..." --body "..."                # never --merge, never gh pr merge
+```
+
+The PR body says what was broken, why it happened, how it was fixed, and how it was verified - then
+`Fixes #N`. No attribution footer.
+
+Comment on the issue with a one-line summary and the PR link, so the reporter sees it without reading
+a diff.
+
+## When you cannot finish
+
+Say so in the issue and stop. A half-fix with a passing build is worse than an honest comment: it
+looks addressed and is not. If the repro works but the fix needs a product decision, put the
+reproduction in the issue - that is the expensive half, and it makes the decision easy for whoever
+takes it.

--- a/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateBreakpointType.java
+++ b/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateBreakpointType.java
@@ -42,11 +42,6 @@ public class KarateBreakpointType extends XLineBreakpointType<XBreakpointPropert
     return null;
   }
 
-  @Override
-  public String getDisplayText(XLineBreakpoint<XBreakpointProperties<?>> breakpoint) {
-    return getDisplayTextDefaultWithPathAndLine(breakpoint);
-  }
-
   /**
    * What makes the platform offer a <b>Condition</b> field on the breakpoint - right-click on the
    * gutter icon, or the Breakpoints dialog. Without a provider here the field is simply absent, and a

--- a/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugProcess.java
+++ b/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugProcess.java
@@ -12,9 +12,9 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.ToggleAction;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.MessageType;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.ColoredTextContainer;
@@ -293,7 +293,8 @@ public class KarateDebugProcess extends XDebugProcess implements KarateDebugChan
   }
 
   private @Nullable XSourcePosition sourcePosition(KarateDebugChannel.Paused paused) {
-    VirtualFile file = ReadAction.compute(() -> FeaturePathResolver.findFeatureFile(project, paused.path()));
+    VirtualFile file = ApplicationManager.getApplication().runReadAction(
+      (Computable<VirtualFile>) () -> FeaturePathResolver.findFeatureFile(project, paused.path()));
     if (file == null) {
       report("Could not find " + paused.path() + " in this project, so the paused line cannot be shown.");
       return null;

--- a/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugRunner.java
+++ b/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugRunner.java
@@ -41,6 +41,12 @@ public class KarateDebugRunner extends GenericProgramRunner<RunnerSettings> {
     return DefaultDebugExecutor.EXECUTOR_ID.equals(executorId) && profile instanceof KarateRunConfiguration;
   }
 
+  /**
+   * Uses {@code XDebuggerManager.newSessionBuilder}, which the verifier reports as experimental API on
+   * 261 and no longer flags on 262 and up. The alternative is
+   * {@code XDebugSession.getRunContentDescriptor()}, which is deprecated and logs a throwable in split
+   * mode - so this is deliberately the forward-facing half of that choice rather than the quiet one.
+   */
   @Override
   protected RunContentDescriptor doExecute(@NotNull RunProfileState state,
     @NotNull ExecutionEnvironment environment) throws ExecutionException {

--- a/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java
+++ b/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java
@@ -20,13 +20,13 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.OrderEnumerator;
 import com.intellij.openapi.roots.libraries.LibraryUtil;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -397,7 +397,7 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
 
   /** Feature files that still carry a Java line breakpoint, newest platform state each time. */
   private static List<String> staleJavaBreakpointFiles(Project project) {
-    return ReadAction.compute(() -> Arrays.stream(
+    return ApplicationManager.getApplication().runReadAction((Computable<List<String>>) () -> Arrays.stream(
         XDebuggerManager.getInstance(project).getBreakpointManager().getAllBreakpoints())
       .filter(breakpoint -> JAVA_LINE_BREAKPOINT_TYPE.equals(breakpoint.getType().getId()))
       // A disabled leftover confuses nobody, and refusing a run over one would be its own annoyance.


### PR DESCRIPTION
Two unrelated small things, together so there is one PR to merge.

**Verifier findings from the debugger work.** All three IDEs already reported `Compatible`; these were the strictness flags.

- `getDisplayText` overrode the base implementation with a call to the internal `getDisplayTextDefaultWithPathAndLine` — which is exactly what the base method already does, so the override existed only to reach past an API boundary. Deleted.
- `ReadAction.compute(ThrowableComputable)` is deprecated. Both call sites want a plain blocking read on the thread they are already on, so they use `Application.runReadAction(Computable)`, the idiom the rest of the plugin uses.

Kept, with a comment saying why: `XDebugSessionBuilder` is experimental on 261 and unflagged on 262/263. The alternative is a deprecated getter that logs a throwable in split mode.

`verifyPlugin` now: Compatible on 261, 262 and 263, experimental usages only.

**A `fix-issues` skill.** Say "fix issues" and it triages open issues, fixes the ones that are reproducible bugs, and opens one PR each without merging. Feature requests, questions and anything needing a product decision get a comment instead. It encodes the repo-specific parts: reproduce through a unit test, the fixture or the debug harnesses before fixing, `integrationTest` for anything touching runs or the debugger, and the fixture line numbers that other tests pin.

`check` green.