### PR TITLE
Prune superseded caches by count, not only by age

### DIFF
--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -13,8 +13,9 @@
 # least-recently-used - is what this repository already tried: LRU is blind, and it took the 1.7 GB
 # IDE Starter archive and live dependency bundles with it while every job re-downloaded.
 #
-# What counts as dead: an entry that is not the most recent of its family and has not been read for
-# seven days.
+# What counts as dead: anything but the newest of its family. The seven-day unread rule remains for
+# families where more than one entry is kept (KEEP_PER_FAMILY above), and is deliberately not the only
+# rule: a busy day mints new entries faster than a week-long cutoff can retire the old ones.
 #
 # The read rule has a blind spot worth knowing. It can only reclaim an entry that jobs have stopped
 # restoring, and a job goes on restoring its own job-id lineage even after it is made
@@ -58,6 +59,10 @@ jobs:
           REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
           KEEP_UNREAD_SECONDS: '604800' # seven days
+          # One. A superseded dependency cache is not a useful fallback: restore-keys match by prefix
+          # and take the newest, so a build whose hash has moved on restores the current entry either
+          # way. Keeping two costs ~3.4 GB to insure against a revert that would re-download once.
+          KEEP_PER_FAMILY: '1'
         run: |
           set -euo pipefail
 
@@ -68,14 +73,25 @@ jobs:
           echo "Total: $(jq 'length' caches.json) entries, \
           $(jq '[.[].size] | add / 1000000 | round' caches.json) MB"
 
-          # Never drop the newest of a family, however old; drop the rest once they go unread.
-          jq -r --argjson cutoff "$(( $(date -u +%s) - KEEP_UNREAD_SECONDS ))" '
+          # Two rules, because the age rule alone cannot keep up with a busy day. Every entry beyond
+          # the newest KEEP_PER_FAMILY of its family goes immediately: a dependency cache superseded
+          # twice over is dead whatever its last-read says. Between those, the older ones go once they
+          # have been unread for KEEP_UNREAD_SECONDS.
+          #
+          # Why the age rule is not enough on its own: each push to main that touches a build file
+          # mints a fresh ~1.9 GB dependency cache and a ~1.5 GB transforms cache. Seven merges in two
+          # days is 25 GB of entries all younger than the seven-day cutoff, which is how this
+          # repository reached its ceiling the day after the cache work that was meant to fix it.
+          jq -r --argjson cutoff "$(( $(date -u +%s) - KEEP_UNREAD_SECONDS ))" \
+                --argjson keep "$KEEP_PER_FAMILY" '
             map(.family = (.key
                   | sub("-[0-9]{4}-[0-9]{2}$"; "")
                   | sub("-[0-9a-f]{8,}$"; "")))
             | group_by(.family)
-            | map(sort_by(.used) | reverse | .[1:]
-                  | map(select((.used | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) < $cutoff)))
+            | map(sort_by(.used) | reverse
+                  | (.[$keep:])                                    # beyond the keep count: always
+                    + (.[1:$keep] | map(select(                    # between: once unread long enough
+                        (.used | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) < $cutoff))))
             | flatten
             | .[] | [.id, .size, .key] | @tsv
           ' caches.json > prune.tsv


### PR DESCRIPTION
The repository hit its 25 GB cache ceiling the day after the cache work meant to fix it.

Not a regression in that work. The rule retired an entry only once it had gone unread for seven days, and seven merges to main in two days minted seven ~1.9 GB dependency caches and five ~1.5 GB transforms caches — all younger than the cutoff, so nothing was eligible and nothing was collected.

Anything beyond the newest of a family now goes immediately, whatever its age. A superseded dependency cache is not a useful fallback anyway: `restore-keys` match by prefix and take the newest, so a build whose hash has moved on restores the current entry either way.

Measured against the live cache list:

| | |
|---|---|
| now | 25.50 GB across 78 entries |
| after | 7.09 GB — frees 18.4 GB |

Keeping two per family instead of one leaves 10.9 GB; that 3.4 GB insures against a revert that would re-download once, which is not worth it at this ceiling.

The stale `ide-starter-Linux-<hash>` entry from the old key scheme is not caught — it is the only member of its family, so it always looks newest — but nothing reads it any more and the 30-day retention will take it.

Run **prune-caches** with `dry_run` first if you want to see the list before it deletes.