### PR TITLE
Offer the JVM debugger as an opt-in second tab

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -11,13 +11,29 @@ Entries go under `## [Unreleased]` in [Keep a Changelog](https://keepachangelog.
 ## Sections
 
 Use the existing section under `[Unreleased]`, creating it only if absent. Order as they appear
-in the file: `### Added`, `### Modified`, `### Fixed`.
+in the file: `### Highlights`, `### Added`, `### Modified`, `### Fixed`.
 
 | Section | Use for |
 |---|---|
+| `Highlights` | The few changes worth interrupting a user about. **This is the only section they see** |
 | `Added` | New capability that did not exist before |
 | `Modified` | Existing behavior that now works differently (including intentional behavior changes) |
 | `Fixed` | Something that was broken and now is not |
+
+## Highlights, and why the other sections are not it
+
+`build.gradle.kts` renders `### Highlights` alone into the Marketplace change notes and the IDE's
+update notification. Everything else stays in the file, for the repo.
+
+- **Three bullets at most**, one or two sentences each. It is a popup, read by someone who did not
+  ask to read it.
+- Write the highlight *and* the full entry. A highlight repeating a bullet's subject in shorter
+  words is the intent, not duplication to avoid.
+- Most changes do not earn one. A fix nobody reported, an internal change, a doc tweak: `Fixed` or
+  `Modified` only. Ask whether a user would want the IDE to tell them.
+- A release with no `Highlights` broadcasts its **whole** entry as a fallback, so that notes are
+  never empty. That is the pre-convention behaviour, not a way to opt out - if a release has
+  anything worth saying, say it in three bullets rather than letting all of it through.
 
 ## Writing the entry
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Highlights
+
+- **Debug the Java a feature calls.** Tick **Attach the JVM debugger too** on a Karate run
+  configuration and Debug opens a second tab where Java breakpoints stop - for code reached through
+  `Java.type(...)`, or for stepping into Karate itself. Off by default.
+
 ### Added
 
 - **An opt-in JVM debugger, in its own tab.** Karate runs are debugged by the plugin itself, with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- **An opt-in JVM debugger, in its own tab.** Karate runs are debugged by the plugin itself, with no
+  JDWP, which is what lets both Karate majors stop on the step and show the scenario's own variables -
+  but it leaves no way to stop in Java a feature calls through `Java.type(...)`, or to step into
+  karate-core. Tick **Attach the JVM debugger too** in the run configuration and Debug opens a second
+  tab, an ordinary Remote JVM Debug session on the same test JVM, where Java breakpoints stop as
+  usual. The Karate tab keeps its own breakpoints on the feature. Off by default: a Java breakpoint
+  suspends every thread in the JVM, so while the Java tab is stopped the Karate tab answers nothing
+  until you resume it - nothing is lost, but it is a surprise nobody should get without asking.
+
+### Fixed
+
+- The run configuration's **Debug port** field said "will suspend if set". It has not suspended
+  anything since 3.1.0, where it became the port the Karate debugger listens on.
+
 ## [3.1.0] - 2026-09-07
 
 Since 3.0, Uppercut has gained two things worth knowing about: **Karate 2 support**, and **debugging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,8 @@ Versions are pinned in those two files and bumped by dependabot; the table names
 
 Update `CHANGELOG.md` for every major change. Add entries under the `## [Unreleased]` section using [Keep a Changelog](https://keepachangelog.com) format (`### Added`, `### Fixed`, `### Modified`, etc.). The CI deploy action handles version bumping and release — do not manually create version entries.
 
+**`### Highlights` is the only section users see.** `build.gradle.kts` renders that section alone into the Marketplace change notes and the IDE's update notification; everything else stays in the file for the repo. Three bullets at most, each one or two sentences, written for someone reading a popup they did not ask for — a release where nothing is worth interrupting anyone about can have no Highlights at all, though then the whole entry is broadcast as a fallback, so prefer writing one. Detail still belongs under `Added`/`Fixed`/`Modified`; a highlight is allowed to repeat a bullet's subject in shorter words.
+
 ## Common Tasks
 
 ### Adding a New Inspection

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,19 +191,35 @@ intellijPlatform {
             }
 
         val changelog = project.changelog // local variable for configuration cache compatibility
-        // Get the latest available change notes from the changelog file. The docs link goes first in
-        // every version's notes here, rather than as a line in CHANGELOG.md that someone has to
-        // remember to keep.
+        // Locals, not script-level constants: the configuration cache cannot serialize a reference
+        // back into the script object, which is why `changelog` above is a local too.
+        //
+        // The one CHANGELOG.md section that reaches the Marketplace and the IDE's update
+        // notification. Three bullets at most: it is read in a popup, by someone who did not ask to
+        // read it.
+        val highlightsSection = "Highlights"
+        // What the IDE shows in its update notification, which is a popup rather than a record: the
+        // release's `### Highlights` section alone, and nothing else. CHANGELOG.md keeps every
+        // Added/Modified/Fixed line - the repo needs those, and nobody reads them in an update
+        // dialog. A release with no Highlights falls back to the whole entry, so the notes are never
+        // empty; that is also what every release before this convention gets.
+        //
+        // Highlights are read off Item.sections rather than through withFilter, which filters item
+        // text and not section names. The docs link goes first in every version's notes here, rather
+        // than as a line in CHANGELOG.md that someone has to remember to keep.
         changeNotes = properties("pluginVersion").map { pluginVersion ->
             val docsLink = "<p>What works, what's in progress, and what every setting means: " +
                 "<a href=\"https://rankweis.github.io/uppercut/\">rankweis.github.io/uppercut</a></p>\n"
-            docsLink + with(changelog) {
-                renderItem(
-                    (getOrNull(pluginVersion) ?: getUnreleased())
-                        .withHeader(false)
-                        .withEmptySections(false),
-                    Changelog.OutputType.HTML,
-                )
+            val item = with(changelog) { getOrNull(pluginVersion) ?: getUnreleased() }
+            val highlights = item.sections[highlightsSection].orEmpty()
+            docsLink + when {
+                highlights.isNotEmpty() -> markdownToHTML(highlights.joinToString("\n") { "- $it" })
+                else -> with(changelog) {
+                    renderItem(
+                        item.withHeader(false).withEmptySections(false),
+                        Changelog.OutputType.HTML,
+                    )
+                }
             }
         }
     }

--- a/docs/DEBUGGER.md
+++ b/docs/DEBUGGER.md
@@ -184,9 +184,11 @@ name, a 5 s hold, `RESUME`, suite passes.
 
 **What automated tests now cover, and what they do not.** `Karate2UITest.debuggerPausesOnAFailedStep`
 debugs the fixture's broken feature in a real IDE and asserts the session suspends on the failing
-step, steps, and resumes - possible only because pausing on a failure needs no breakpoint UI.
-Breakpoint registration through the gutter, the variables tree and the conditions field are still
-only exercised by hand. That is the same gap
+step, steps, and resumes - it needs no breakpoint UI, which is why it was the first one written.
+`theJvmDebuggerIsOptInAndRunsBesideTheKarateOne` (phase 6) does set breakpoints, through the
+`ToggleLineBreakpoint` action with the caret placed - the same path the gutter takes - so breakpoint
+registration is covered on both a feature step and a Java line. The variables tree and the conditions
+field are still only exercised by hand. That is the same gap
 v1 debugging has always had, and it is why `docs/manual-test-checklist.md` has a debugger section -
 walked end to end on 2026-09-06, which is what found the three phase-2 bugs: two breakpoint types
 claiming one line, `XDebuggerEditorsProvider.createDocument` throwing `AbstractMethodError` before
@@ -376,8 +378,8 @@ follow from the spike:
   both through one setting would be a worse answer than a free port for the one that needs no pinning.
 
 Still open: what a Stop in one tab should do to the other. Today they are independent - stopping the
-Java tab detaches it and leaves the run going, which is the useful direction; stopping the Karate tab
-kills the JVM under the Java tab, which is honest but abrupt.
+Java tab detaches it and leaves the run going, which is the useful direction and is asserted by the
+UI test; stopping the Karate tab kills the JVM under the Java tab, which is honest but abrupt.
 
 ## Decisions still open
 

--- a/docs/DEBUGGER.md
+++ b/docs/DEBUGGER.md
@@ -1,6 +1,7 @@
 # Debugging — one debugger for both Karate versions
 
-Status: **shipping in 3.1.0: one debugger, both majors, one tab.** A breakpoint on a `.feature` step pauses the
+Status: **shipping in 3.1.0: one debugger, both majors, one tab.** An opt-in JVM
+debugger in a second tab is spiked but not built - see "Phase 6 spike" below. A breakpoint on a `.feature` step pauses the
 run, highlights the line, shows the scenario's variables and evaluates Karate expressions in it - on
 Karate 1 through `RuntimeHook.beforeStep`, on Karate 2 through `Runner.debugSupport`. The JDI path
 and JDWP are gone; so are Java breakpoints during a Karate run. Deliberately not built: breakpoint
@@ -285,12 +286,88 @@ Docs move with phases 2 and 4, not at the end: `site/status.md`'s debugging tabl
 `site/troubleshooting.md:96`, the settings text for the debug port, and the v2 console notice in
 `KarateRunConfiguration:263-270` that tells users feature breakpoints will not fire.
 
+## Phase 6 spike - an opt-in JVM debugger (2026-09-07)
+
+Phase 4 deleted JDWP outright. The question this spike answers is whether it can come back as an
+**opt-in second tab** - not for feature lines, which the agent owns on both majors now, but for the
+one thing the agent cannot reach: Java a feature calls through `Java.type`, and karate-core itself.
+
+Wiring JDWP back on is a dozen lines; it was never the hard part. The hard part was
+`KaratePositionManager` mapping a Gherkin step to bytecode through
+`StepRuntime.findMethodsMatching`, and `UppercutClassLoader` loading the user's jars into the IDE's
+own JVM to do it. None of that is needed for Java breakpoints in Java files, and with feature lines
+belonging to one breakpoint type there is no second claim on a line either. So the only real
+question is what two debuggers do to each other inside one JVM.
+
+`JdwpClashProbe` answers it, in both fixture modules: a parent process that is a stand-in for the
+IDE with **both tabs open** - it listens on the Karate debug channel and attaches JDI to the child -
+against a child that is a real Karate suite under the real agent, launched with JDWP the way an
+opt-in Debug run would launch it.
+
+```
+./gradlew :KarateTestRunner:classes
+../../gradlew -p testProjects/karate-versions :v1:jdwpClash
+../../gradlew -p testProjects/karate-versions :v2:jdwpClash
+../../gradlew -p testProjects/karate-versions :v2:jdwpClash -Pparallelism=2
+```
+
+`sample/javacall.feature` and `sample/Helper.java` are new in both modules and exist for this: a
+feature that calls the user's own Java, which is the whole case an opt-in JVM debugger would serve.
+
+**`Java.type` reaches user Java on both majors.** Karate 2's own JS engine handles it as Karate 1's
+Graal does - `Helper.compute(20)` ran and returned 41 under both. The feature is not v1-only.
+
+**The two debuggers coexist.** JDWP attached, the agent connected, breakpoints on both sides bound,
+the suite passed. Launching `suspend=y` is safe: the child runs nothing until JDI resumes it, so the
+agent's handshake window does not start until the Java side has attached. No ordering hazard.
+
+**A Java breakpoint freezes the Karate tab, on both majors.** This is the finding. The default
+suspend policy is all-threads, and one of those threads is `uppercut-debug-reader`. With the VM
+suspended the channel answered nothing in 5 s, having answered in 2 ms a moment earlier. Stopped at
+the real breakpoint in `Helper.compute` it was frozen again. Variables, evaluate and resume in the
+Karate tab all stop working for as long as the Java tab holds the VM.
+
+**Nothing is lost, though.** Commands sent during the suspension sit in the socket and are acted on
+2 ms after the VM resumes - the `VARIABLES` reply and a `RESUME` issued mid-suspension both landed.
+So the failure mode is a tab that appears dead and then catches up, not a dropped command or a
+parked JVM. Recoverable, and the user's way out - resume the Java tab - is the obvious one.
+
+**Karate 2's virtual threads are the sharp edge.** A Java breakpoint on a scenario running on a
+virtual thread *does* hit (`virtual: true`, at `parallelism=2`). But `VirtualMachine.allThreads()`
+never lists them - 0 of 4 at attach, and the paused scenario thread was not visible to JDI at all -
+so the Java tab's thread list is empty of exactly the threads the run is using until one stops. And
+JDI's id for the thread that did stop has nothing to do with the `vt-38` key the Karate tab shows,
+so the two tabs cannot be lined up by thread. Forcing `parallel(1)` under Debug, which the run
+configuration already does, puts the scenario back on `main` and makes the Java tab coherent - which
+turns a UI preference into a requirement for this feature.
+
+### What that means for the design
+
+Worth doing, opt-in and off by default, with the freeze documented rather than engineered around:
+it is the ordinary behaviour of a Java breakpoint, the Karate tab recovers by itself, and a user who
+opted into a second debugger has some reason to expect a second debugger's semantics. Two things
+follow from the spike:
+
+- **Route it through a stock Remote JVM Debug session** (`RemoteConfigurationType` +
+  `ProgramRunnerUtil.executeConfiguration`) rather than attaching one ourselves.
+  `KarateDebugRunner.canRun` already claims the Debug executor ahead of `GenericDebuggerRunner`, so
+  the alternative is `DebuggerManagerEx.attachVirtualMachine` and `RemoteConnectionBuilder` - the
+  `com.intellij.debugger.impl` package that commit `9211463` just finished getting off. The stock
+  session is public API, is genuinely a separate tab, and detaching it leaves the run alive.
+- **`--parallelism 1` is load-bearing** once JDWP is on, for the virtual-thread reason above, not
+  only for the "a suspended run is easier to follow" reason it was chosen for.
+
+Not answered by this spike, and worth knowing before shipping: which port the opt-in uses (the
+existing **Debug port** field is the Karate channel's now), and what a Stop in one tab does to the
+other.
+
 ## Decisions still open
 
-- ~~Two Debug tabs, or one?~~ **Decided: two.** Keeping JDWP for Java step-def breakpoints means a
-  second session, and that is the shipping answer, not a placeholder. It costs nothing to revisit:
-  the JDWP launch exists today and stays either way, and a later single-tab experiment would replace
-  IDE-side session plumbing only — no agent, protocol or adapter work is thrown away.
+- ~~Two Debug tabs, or one?~~ **Shipping: one, with a second one opt-in.** The question was asked
+  twice and answered twice. Phase 4 settled the default - a Karate run attaches no JVM debugger, so
+  there is one tab - and the phase 6 spike above settles the follow-up: a JVM debugger can come back
+  as an opt-in second tab, off unless asked for, because its only real cost is a Karate tab that goes
+  unresponsive while the Java tab holds the VM, and that recovers by itself. Not yet built.
 - **Breakpoints mid-run.** The launch-time snapshot is much simpler. Adding and removing while
   paused needs the IDE→runner direction of the protocol, which Phase 1 should leave room for.
 - **Protocol.** Own JSON lines, not DAP - already built. Worth recording that 2026.2 does ship an

--- a/docs/DEBUGGER.md
+++ b/docs/DEBUGGER.md
@@ -1,7 +1,7 @@
 # Debugging — one debugger for both Karate versions
 
-Status: **shipping in 3.1.0: one debugger, both majors, one tab.** An opt-in JVM
-debugger in a second tab is spiked but not built - see "Phase 6 spike" below. A breakpoint on a `.feature` step pauses the
+Status: **shipping in 3.1.0: one debugger, both majors, one tab.** A JVM
+debugger in a second tab is opt-in per run configuration - see "Phase 6" below. A breakpoint on a `.feature` step pauses the
 run, highlights the line, shows the scenario's variables and evaluates Karate expressions in it - on
 Karate 1 through `RuntimeHook.beforeStep`, on Karate 2 through `Runner.debugSupport`. The JDI path
 and JDWP are gone; so are Java breakpoints during a Karate run. Deliberately not built: breakpoint
@@ -286,7 +286,7 @@ Docs move with phases 2 and 4, not at the end: `site/status.md`'s debugging tabl
 `site/troubleshooting.md:96`, the settings text for the debug port, and the v2 console notice in
 `KarateRunConfiguration:263-270` that tells users feature breakpoints will not fire.
 
-## Phase 6 spike - an opt-in JVM debugger (2026-09-07)
+## Phase 6 - an opt-in JVM debugger (2026-09-07)
 
 Phase 4 deleted JDWP outright. The question this spike answers is whether it can come back as an
 **opt-in second tab** - not for feature lines, which the agent owns on both majors now, but for the
@@ -348,7 +348,7 @@ it is the ordinary behaviour of a Java breakpoint, the Karate tab recovers by it
 opted into a second debugger has some reason to expect a second debugger's semantics. Two things
 follow from the spike:
 
-- **Route it through a stock Remote JVM Debug session** (`RemoteConfigurationType` +
+- **Routed through a stock Remote JVM Debug session** (`RemoteConfigurationType` +
   `ProgramRunnerUtil.executeConfiguration`) rather than attaching one ourselves.
   `KarateDebugRunner.canRun` already claims the Debug executor ahead of `GenericDebuggerRunner`, so
   the alternative is `DebuggerManagerEx.attachVirtualMachine` and `RemoteConnectionBuilder` - the
@@ -357,9 +357,27 @@ follow from the spike:
 - **`--parallelism 1` is load-bearing** once JDWP is on, for the virtual-thread reason above, not
   only for the "a suspended run is easier to follow" reason it was chosen for.
 
-Not answered by this spike, and worth knowing before shipping: which port the opt-in uses (the
-existing **Debug port** field is the Karate channel's now), and what a Stop in one tab does to the
-other.
+### What was built
+
+`KarateJvmDebuggerAttach` runs a stock `RemoteConfigurationType` configuration against a JDWP port
+`KarateRunConfiguration.openJvmDebugPort` opens for the launch, gated on the run configuration's
+`attachJvmDebugger` flag. Three things are worth knowing about it:
+
+- **`server=y,suspend=n`.** `suspend=y` would guarantee that nothing runs before the attach, at the
+  price of a test JVM parked forever if the attach never happens - the one outcome this debugger goes
+  out of its way to avoid. The guarantee comes from the Karate handshake instead:
+  `KarateDebugChannel.holdForJvmDebugger` withholds `BREAKPOINTS_END`, which the agent waits for
+  before its first step, until the remote session starts. So the JVM itself never waits.
+- **The hold has its own backstop, and it is short.** Eight seconds, against the agent's fifteen.
+  Holding past the agent's own timeout would start the suite with no breakpoint set at all - a JVM
+  debugger that never arrives has to cost the user its own breakpoints, never Karate's. The process
+  handler releases it early if the run dies first.
+- **A port per launch, not a field.** The **Debug port** field is the Karate channel's, and pinning
+  both through one setting would be a worse answer than a free port for the one that needs no pinning.
+
+Still open: what a Stop in one tab should do to the other. Today they are independent - stopping the
+Java tab detaches it and leaves the run going, which is the useful direction; stopping the Karate tab
+kills the JVM under the Java tab, which is honest but abrupt.
 
 ## Decisions still open
 
@@ -367,7 +385,7 @@ other.
   twice and answered twice. Phase 4 settled the default - a Karate run attaches no JVM debugger, so
   there is one tab - and the phase 6 spike above settles the follow-up: a JVM debugger can come back
   as an opt-in second tab, off unless asked for, because its only real cost is a Karate tab that goes
-  unresponsive while the Java tab holds the VM, and that recovers by itself. Not yet built.
+  unresponsive while the Java tab holds the VM, and that recovers by itself. Built; see phase 6.
 - **Breakpoints mid-run.** The launch-time snapshot is much simpler. Adding and removing while
   paused needs the IDE→runner direction of the protocol, which Phase 1 should leave room for.
 - **Protocol.** Own JSON lines, not DAP - already built. Worth recording that 2026.2 does ship an

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -114,24 +114,32 @@ launches the plugin's runner, not that class.
 
 ## 6c. The opt-in JVM debugger
 
-Off by default, so none of 6b changes when it is not ticked. `JdwpClashProbe` covers the mechanism
-headlessly on both majors (`:v1:jdwpClash`, `:v2:jdwpClash`) - what only the IDE can show is the two
-tabs. Use `sample/javacall.feature` and `sample/Helper.java`, which exist for this, on either module.
-**Not yet walked.**
+Off by default, so none of 6b changes when it is not ticked. Most of this is now automated:
+`Karate2UITest.theJvmDebuggerIsOptInAndRunsBesideTheKarateOne` runs `sample/javacall.feature` twice
+in a real IDE, unticked and ticked, and `JdwpClashProbe` covers the mechanism headlessly on both
+majors (`:v1:jdwpClash`, `:v2:jdwpClash`). What is left by hand is what an assertion cannot see.
 
+Automated - listed so a failure is read against what it was meant to prove, not re-walked:
+
+- [x] Unticked: Debug opens one tab and no "Karate JVM debugger" tab exists.
+- [x] Ticked: a second tab appears and the Java breakpoint in `Helper.compute` suspends the run there.
+- [x] The Karate tab still stops on its own feature-line breakpoint in the same run.
+- [x] A breakpoint on the first Java the run touches binds - `Helper` is loaded a step before the
+      Karate breakpoint, so this only passes because the handshake held the run for the attach.
+- [x] Stop the Java tab alone: it detaches and the Karate run finishes.
+
+Still by hand. **Walked 2026-09-07** for the two marked below; the rest are unwalked.
+
+- [x] Ticked: the Java tab stops in `Helper.compute` *and* the Karate tab stops on the step - both,
+      in one run.
 - [ ] **Attach the JVM debugger too** appears in the run configuration's Test Options and survives a
-      close and reopen of the dialog.
-- [ ] Unticked: Debug opens one tab, as in 6b, and a Java breakpoint in `Helper.compute` does not stop.
-- [ ] Ticked: Debug opens a second tab, "Karate JVM debugger", and the Java breakpoint in
-      `Helper.compute` stops the run there with Java frames and locals - `seed`, `doubled`.
-- [ ] The Karate tab still stops on a feature-line breakpoint in the same run, with Karate's variables.
+      close and reopen of the dialog. *(The setting's round-trip is unit-tested; this is the widget.)*
+- [ ] The Java tab shows real frames and locals - `seed`, `doubled` - not just a suspended session.
 - [ ] While the Java tab is stopped, the Karate tab's variables, Evaluate and Resume do nothing, and
       catch up when the Java tab resumes. **This is the expected behaviour**, documented on the
       troubleshooting page; the point of the check is that it catches up rather than staying dead.
-- [ ] A breakpoint on the *first* Java the run touches still binds - the handshake hold is what makes
-      that work, so this is the check that the hold is doing its job.
-- [ ] Resume both, and the suite finishes normally with nothing failed.
-- [ ] Stop the Java tab alone: it detaches and the Karate run keeps going.
+      Automating it would mean asserting on a timeout, which is the flakiest thing this suite could
+      own - and `JdwpClashProbe` already pins the mechanism.
 - [ ] Stop the Karate tab: the test JVM dies and the Java tab ends with it; no java process left
       behind (`jps`).
 

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -106,11 +106,34 @@ then the whole list again on v1 after phase 4 moved it onto the same debugger.
       not be reached - that is not a fault.)*
 - [x] The step buttons continue to the next breakpoint and say so.
 - [x] Stop while paused ends the run with no java process left behind (`jps`).
-- [x] Karate 1 and Karate 2 both open a single Debug tab; no JVM debugger attaches.
+- [x] Karate 1 and Karate 2 both open a single Debug tab; no JVM debugger attaches. *(Unless the run
+      configuration asks for one - see 6c.)*
 
-Not covered, for want of a fixture: a breakpoint in Java a feature calls through `Java.type(...)`.
 A breakpoint in the `@Karate.Test` JUnit class proves nothing here - a Karate run configuration
 launches the plugin's runner, not that class.
+
+## 6c. The opt-in JVM debugger
+
+Off by default, so none of 6b changes when it is not ticked. `JdwpClashProbe` covers the mechanism
+headlessly on both majors (`:v1:jdwpClash`, `:v2:jdwpClash`) - what only the IDE can show is the two
+tabs. Use `sample/javacall.feature` and `sample/Helper.java`, which exist for this, on either module.
+**Not yet walked.**
+
+- [ ] **Attach the JVM debugger too** appears in the run configuration's Test Options and survives a
+      close and reopen of the dialog.
+- [ ] Unticked: Debug opens one tab, as in 6b, and a Java breakpoint in `Helper.compute` does not stop.
+- [ ] Ticked: Debug opens a second tab, "Karate JVM debugger", and the Java breakpoint in
+      `Helper.compute` stops the run there with Java frames and locals - `seed`, `doubled`.
+- [ ] The Karate tab still stops on a feature-line breakpoint in the same run, with Karate's variables.
+- [ ] While the Java tab is stopped, the Karate tab's variables, Evaluate and Resume do nothing, and
+      catch up when the Java tab resumes. **This is the expected behaviour**, documented on the
+      troubleshooting page; the point of the check is that it catches up rather than staying dead.
+- [ ] A breakpoint on the *first* Java the run touches still binds - the handshake hold is what makes
+      that work, so this is the check that the hold is doing its job.
+- [ ] Resume both, and the suite finishes normally with nothing failed.
+- [ ] Stop the Java tab alone: it detaches and the Karate run keeps going.
+- [ ] Stop the Karate tab: the test JVM dies and the Java tab ends with it; no java process left
+      behind (`jps`).
 
 ## 7. Environment matrix
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.rankweis.uppercut
 pluginName = Uppercut for Karate
 pluginRepositoryUrl = https://github.com/rankweis/uppercut
 # SemVer format -> https://semver.org
-pluginVersion = 3.1.1
+pluginVersion = 3.2.0
 karateVersion = 1.5.2
 logbackVersion = 1.5.38
 

--- a/site/settings.md
+++ b/site/settings.md
@@ -61,6 +61,9 @@ Parallelism
 Debug: pause when a step fails
 : On by default. A Debug run stops on a step that fails, with the scenario still standing - the error is shown and the variables are as the failure left them, so you can see what `response` actually held. The Debug toolbar has a **Pause on Failed Step** toggle for the same thing, which takes effect on the next step rather than the next run - reach for that when a suite is failing in twenty places and stopping at each one is not what you came for. Toggling it there changes this setting too.
 
+Attach the JVM debugger too
+: Off by default. Opens a second Debug tab - an ordinary Remote JVM Debug session on the same test JVM - so Java breakpoints stop during the run. Worth it for Java a feature calls through `Java.type(...)`, or for stepping into karate-core; the Karate tab keeps its own breakpoints on the feature either way. Expect the Karate tab to stop answering while the Java tab is stopped, since a Java breakpoint suspends the whole JVM - see the [troubleshooting page](troubleshooting).
+
 Debug port
 : Only used when you start the configuration with **Debug** rather than Run. The IDE listens on this port for the test JVM's debug connection; leave it blank and a free port is picked for you. Set it when a firewall or a container only allows certain ports through. See the [status page](status#debugging) for what the debugger does.
 

--- a/site/status.md
+++ b/site/status.md
@@ -65,7 +65,7 @@ These are the same for Karate 1 and Karate 2 - the language is the same.
 | Step over vs into a called feature | Not yet - stepping enters the called feature | Not yet - stepping enters the called feature |
 | Breakpoint conditions | Early access | Early access |
 | Skip the step the run is stopped on | Early access | Early access |
-| Java breakpoints during a Karate run | Not supported - see below | Not supported - see below |
+| Java breakpoints during a Karate run | Opt-in, second tab | Opt-in, second tab |
 
 **One debugger, both majors.** Put a breakpoint on a step in a `.feature` file and press Debug: the
 run stops before that step, the line is highlighted, and the debugger shows the scenario's variables -
@@ -74,13 +74,22 @@ run stops before that step, the line is highlighted, and the debugger shows the 
 feature. Resume continues to the next breakpoint or to the end. Scenarios run one at a time while
 debugging, whatever the parallelism setting says, so a suspended run is followable.
 
-**Java breakpoints no longer stop during a Karate run.** Karate has no user-written step definitions -
-the DSL lives inside karate-core - so the JVM debugger was only ever reachable for Java a feature
-calls through `Java.type(...)`, and for stepping into Karate itself. Karate runs are now debugged by
-the plugin directly, without JDWP, which is what makes both majors stop on the step and show Karate's
-own variables. To debug Java called from a feature, run the `@Karate.Test` JUnit class through
-IntelliJ's ordinary Java or Gradle test configuration, where the JVM debugger works as usual; that
-run has no feature-file breakpoints.
+**Java breakpoints are off unless you ask for them.** Karate has no user-written step definitions -
+the DSL lives inside karate-core - so the JVM debugger is not how you stop on a step; the plugin does
+that itself on both majors, without JDWP, which is what lets it show Karate's own variables. The JVM
+debugger is still the only way to reach Java a feature calls through `Java.type(...)`, or to step
+into karate-core, so a run configuration can ask for it: tick **Attach the JVM debugger too** and
+Debug opens a second tab, an ordinary Remote JVM Debug session on the same test JVM. Java breakpoints
+in your `.java` files then stop the run as they always did, and the Karate tab keeps its own
+breakpoints on the feature.
+
+One thing to expect when both are on: **while the Java tab is stopped, the Karate tab does not
+answer.** A Java breakpoint suspends every thread in the JVM, including the one the Karate debugger
+talks over, so its variables, Evaluate and Resume do nothing until you resume the Java tab. Nothing
+is lost - whatever you clicked is acted on as soon as the JVM is running again - but it is why the
+second debugger is off by default. If you only want Java breakpoints, running the `@Karate.Test`
+JUnit class through IntelliJ's ordinary Java or Gradle test configuration is still the simpler
+answer; that run has no feature-file breakpoints.
 
 **Karate 1 changed here.** Its breakpoints used to be Java breakpoints bound to the bytecode of a
 step-definition method found by matching the step's text, which stopped inside karate-core with Java

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -124,13 +124,25 @@ disabling them instead of deleting them also clears the refusal.
 
 ## A Java breakpoint doesn't stop during a Karate run
 
-By design, since the debugger stopped using JDWP. Karate runs are debugged by the plugin itself,
-which is what lets both Karate majors stop on the step and show the scenario's own variables; there
-is no JVM debugger attached to a Karate run any more.
+No JVM debugger is attached to a Karate run unless the run configuration asks for one. Karate runs
+are debugged by the plugin itself, which is what lets both Karate majors stop on the step and show
+the scenario's own variables.
 
-To debug Java that a feature calls through `Java.type(...)`, run the `@Karate.Test` JUnit class with
-IntelliJ's ordinary Java or Gradle test configuration and debug that - the JVM debugger behaves as
-usual there. That run has no feature-file breakpoints, so the two are used for different questions.
+Tick **Attach the JVM debugger too** in the run configuration and Debug opens a second tab - an
+ordinary Remote JVM Debug session on the same test JVM - where Java breakpoints stop as usual. Use it
+for Java a feature calls through `Java.type(...)`, or to step into karate-core.
+
+The alternative, if feature-file breakpoints are not what you are there for, is to run the
+`@Karate.Test` JUnit class with IntelliJ's ordinary Java or Gradle test configuration and debug that.
+
+## The Karate debugger stops responding while I am stopped in Java
+
+Expected, when a run has both debuggers on. A Java breakpoint suspends every thread in the test JVM,
+and one of those threads is how the Karate tab talks to the run - so its variables tree, Evaluate and
+Resume all do nothing while the Java tab is stopped. Resume the Java tab and the Karate tab catches
+up: whatever you clicked meanwhile is acted on then, not lost.
+
+If that trips you up more than the Java breakpoints help, untick **Attach the JVM debugger too**.
 
 Note that a breakpoint in the `@Karate.Test` class itself never pauses under a **Karate** run
 configuration, and never did: the plugin launches its own runner rather than your JUnit class. Debug

--- a/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/Karate2UITest.kt
+++ b/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/Karate2UITest.kt
@@ -29,7 +29,11 @@ import com.intellij.tools.ide.performanceTesting.commands.openFile
 import com.intellij.tools.ide.performanceTesting.commands.waitForCodeAnalysisFinished
 import com.intellij.tools.ide.performanceTesting.commands.waitForSmartMode
 import com.intellij.tools.ide.starter.product.idea.ultimate.IdeaUltimate
+import com.intellij.driver.sdk.Project
+import com.rankweis.uppercut.karate.ui.util.XDebugSessionRef
+import com.rankweis.uppercut.karate.ui.util.debugConfiguration
 import com.rankweis.uppercut.karate.ui.util.debuggerManager
+import com.rankweis.uppercut.karate.ui.util.runManager
 import com.rankweis.uppercut.karate.ui.util.OutputListenerRef
 import com.rankweis.uppercut.karate.ui.util.ConsoleViewImplRef
 import com.rankweis.uppercut.karate.ui.util.RunContentDescriptor
@@ -76,6 +80,16 @@ class Karate2UITest {
     companion object {
 
         private const val SCREENSHOT_DIR = "build/reports/integrationTest/screenshots/karate2/"
+
+        /** The fixture pair that exists so a JVM debugger has user Java to stop in. */
+        private const val JAVACALL_FEATURE = "v2/src/test/java/sample/javacall.feature"
+        private const val HELPER_JAVA = "v2/src/test/java/sample/Helper.java"
+        /** `* def answer = Helper.compute(seed)` - Karate pauses before it, Java runs inside it. */
+        private const val JAVA_CALL_STEP_LINE = 6
+        /** `int doubled = seed * 2;`, the first statement of Helper.compute. */
+        private const val HELPER_BODY_LINE = 11
+        /** What KarateJvmDebuggerAttach names the second tab. */
+        private const val JVM_DEBUGGER_TAB = "Karate JVM debugger"
 
         private lateinit var run: BackgroundRun
         private lateinit var ideaLog: Path
@@ -373,11 +387,143 @@ class Karate2UITest {
         verifySettingsOverrideBeatsDetection(run.driver)
     }
 
-    /** Runs last while the IDE is still up; idea.log is written through continuously. */
+    /**
+     * The opt-in JVM debugger, in one run without it and one with.
+     *
+     * <p>Both cases in a single test on purpose: each is a real JVM launch and a real Karate suite,
+     * and the interesting assertions are about how the two runs differ - a second test class, or even
+     * a second method, would pay that cost twice to say less.</p>
+     *
+     * <p>This is also the first test in the suite to set a breakpoint. It does it the way the gutter
+     * does, through the ToggleLineBreakpoint action with the caret already placed, so it exercises
+     * breakpoint registration rather than reaching past it into the breakpoint manager.</p>
+     */
     @Test
     @Order(8)
+    fun theJvmDebuggerIsOptInAndRunsBesideTheKarateOne() {
+        val driver = run.driver
+        val project = driver.singleProject()
+        try {
+            toggleBreakpoint(driver, JAVACALL_FEATURE, JAVA_CALL_STEP_LINE)
+            toggleBreakpoint(driver, HELPER_JAVA, HELPER_BODY_LINE)
+
+            // --- Off by default: one tab, and the java breakpoint does not stop the run.
+            openFeature(driver, JAVACALL_FEATURE)
+            launchDebugFromGutterContext(driver)
+            val karateOnly = awaitSuspended(driver, project, "javacall.feature")
+            assertEquals(
+                JAVA_CALL_STEP_LINE - 1, karateOnly.getCurrentPosition()?.getLine(),
+                "the Karate tab should stop before the step that calls Java"
+            )
+            assertEquals(
+                emptyList<String>(), debugTabNames(driver).filter { it.contains(JVM_DEBUGGER_TAB) },
+                "no JVM debugger should attach unless the run asked for one"
+            )
+            karateOnly.resume()
+            awaitRunFinished(driver, project, "javacall.feature")
+
+            // --- Opted in: the same configuration, ticked, launched again.
+            val settings = driver.runManager(project).getSelectedConfiguration()
+            assertNotNull(settings, "the context run should leave its configuration selected")
+            assertTrue(
+                settings.getName().contains("javacall"),
+                "expected the Karate run to be selected, found '${settings.getName()}'"
+            )
+            settings.getConfiguration().setAttachJvmDebugger(true)
+            driver.debugConfiguration(settings)
+
+            // The Karate tab stops first: Karate pauses before the step, Java runs inside it.
+            val karateSession = awaitSuspended(driver, project, "javacall.feature")
+            assertEquals(
+                JAVA_CALL_STEP_LINE - 1, karateSession.getCurrentPosition()?.getLine(),
+                "the Karate tab should still own its own breakpoints with both debuggers on"
+            )
+            waitFor(
+                timeout = 1.minutes,
+                interval = 200.milliseconds,
+                errorMessage = { "No JVM debugger tab appeared; tabs: ${debugTabNames(driver)}" }
+            ) { debugTabNames(driver).any { it.contains(JVM_DEBUGGER_TAB) } }
+
+            karateSession.resume()
+
+            // The class is loaded a step earlier, so this only binds because the handshake held the
+            // run until the JVM debugger attached. It is the whole point of holdForJvmDebugger.
+            val javaSession = awaitSuspended(driver, project, JVM_DEBUGGER_TAB)
+            assertEquals(
+                HELPER_BODY_LINE - 1, javaSession.getCurrentPosition()?.getLine(),
+                "the JVM debugger should stop in Helper.compute"
+            )
+            driver.takeScreenshot(screenshotDir + "08-both-debuggers")
+
+            // Stopping the java tab detaches it and leaves the karate run to finish.
+            javaSession.stop()
+            awaitRunFinished(driver, project, "javacall.feature")
+        } catch (failure: Throwable) {
+            driver.takeScreenshot(screenshotDir + "08-debug-failure")
+            throw failure
+        } finally {
+            sessionsOf(driver, project).filter { !it.isStopped() }.forEach { it.stop() }
+            // Toggling again removes them. A karate breakpoint left in a feature file would make every
+            // later debug run in this IDE stop somewhere the next test does not expect.
+            toggleBreakpoint(driver, JAVACALL_FEATURE, JAVA_CALL_STEP_LINE)
+            toggleBreakpoint(driver, HELPER_JAVA, HELPER_BODY_LINE)
+        }
+    }
+
+    /** Runs last while the IDE is still up; idea.log is written through continuously. */
+    @Test
+    @Order(9)
     fun pluginLoggedNoErrors() {
         assertNoPluginErrorsLogged(ideaLog)
+    }
+
+
+    /** Puts the caret on a line and toggles whatever breakpoint type claims it - the gutter's own action. */
+    private fun toggleBreakpoint(driver: Driver, relativePath: String, line: Int) {
+        driver.execute(
+            CommandChain().openFile(relativePath)
+                .waitForCodeAnalysisFinished()
+                .goto(line, 5)
+        )
+        driver.invokeAction("ToggleLineBreakpoint")
+    }
+
+    /** Every open Debug tab, by the name the user reads on it. */
+    private fun debugTabNames(driver: Driver): List<String> =
+        driver.getRunContentManagerRef(driver.singleProject()).getAllDescriptors()
+            .map { it.getDisplayName() }
+
+    private fun sessionsOf(driver: Driver, project: Project): List<XDebugSessionRef> =
+        driver.getRunContentManagerRef(project).getAllDescriptors().mapNotNull { descriptor ->
+            descriptor.getExecutionConsole()?.let { driver.debuggerManager(project).getDebugSession(it) }
+        }
+
+    private fun sessionNamed(driver: Driver, project: Project, tab: String): XDebugSessionRef? =
+        driver.getRunContentManagerRef(project).getAllDescriptors()
+            .filter { it.getDisplayName().contains(tab) }
+            .mapNotNull { descriptor ->
+                descriptor.getExecutionConsole()?.let { driver.debuggerManager(project).getDebugSession(it) }
+            }
+            .firstOrNull()
+
+    private fun awaitSuspended(driver: Driver, project: Project, tab: String): XDebugSessionRef {
+        waitFor(
+            timeout = 3.minutes,
+            interval = 200.milliseconds,
+            errorMessage = { "The '$tab' debugger never suspended; tabs: ${debugTabNames(driver)}" }
+        ) { sessionNamed(driver, project, tab)?.isSuspended() == true }
+        return sessionNamed(driver, project, tab)!!
+    }
+
+    private fun awaitRunFinished(driver: Driver, project: Project, tab: String) {
+        waitFor(
+            timeout = 3.minutes,
+            interval = 500.milliseconds,
+            errorMessage = { "The debugged run never finished after resuming" }
+        ) {
+            val session = sessionNamed(driver, project, tab)
+            session == null || session.isStopped()
+        }
     }
 
     private fun currentFileName(driver: Driver): String? =

--- a/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/util/DebuggerRefs.kt
+++ b/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/util/DebuggerRefs.kt
@@ -12,10 +12,17 @@ import com.intellij.driver.sdk.Project
 @Remote("com.intellij.xdebugger.XDebuggerManager")
 interface XDebuggerManagerRef {
     fun getCurrentSession(): XDebugSessionRef?
+
+    /**
+     * The session behind one Debug tab. Once a run can open two, {@code getCurrentSession} names
+     * whichever the IDE last focused - so a test that means "the Java one" has to ask by tab.
+     */
+    fun getDebugSession(console: ExecutionConsoleRef): XDebugSessionRef?
 }
 
 @Remote("com.intellij.xdebugger.XDebugSession")
 interface XDebugSessionRef {
+    fun getSessionName(): String
     fun isSuspended(): Boolean
     fun isStopped(): Boolean
     fun getCurrentPosition(): XSourcePositionRef?

--- a/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/util/RunConfigurationRefs.kt
+++ b/src/integrationTest/kotlin/com/rankweis/uppercut/karate/ui/util/RunConfigurationRefs.kt
@@ -1,0 +1,60 @@
+package com.rankweis.uppercut.karate.ui.util
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.client.Remote
+import com.intellij.driver.model.RdTarget
+import com.intellij.driver.sdk.Project
+
+/**
+ * Enough of the run-configuration API to launch one the test has changed.
+ *
+ * A context run (the gutter's `DebugClass`) builds the configuration itself, so there is no way to
+ * tick an option before the first launch. What there is: the configuration it built stays selected,
+ * so a test can reach it afterwards, set the option and launch it again - which is also what a user
+ * does, having run once and then wanted the JVM debugger too.
+ */
+@Remote("com.intellij.execution.RunManager")
+interface RunManagerRef {
+    fun getSelectedConfiguration(): RunnerAndConfigurationSettingsRef?
+}
+
+@Remote("com.intellij.execution.RunnerAndConfigurationSettings")
+interface RunnerAndConfigurationSettingsRef {
+    fun getName(): String
+
+    /**
+     * Typed as the plugin's own configuration: driver refs are structural, so this is a proxy over
+     * whatever object is really there. Assert the name is a Karate run before calling it.
+     */
+    fun getConfiguration(): KarateRunConfigurationRef
+}
+
+@Remote("com.rankweis.uppercut.karate.run.KarateRunConfiguration", plugin = "com.rankweis")
+interface KarateRunConfigurationRef {
+    fun isAttachJvmDebugger(): Boolean
+    fun setAttachJvmDebugger(attach: Boolean)
+}
+
+@Remote("com.intellij.execution.ProgramRunnerUtil")
+interface ProgramRunnerUtilRef {
+    fun executeConfiguration(settings: RunnerAndConfigurationSettingsRef, executor: ExecutorRef)
+}
+
+@Remote("com.intellij.execution.Executor")
+interface ExecutorRef
+
+@Remote("com.intellij.execution.executors.DefaultDebugExecutor")
+interface DefaultDebugExecutorRef {
+    fun getDebugExecutorInstance(): ExecutorRef
+}
+
+fun Driver.runManager(project: Project): RunManagerRef =
+    service(RunManagerRef::class, project, RdTarget.DEFAULT)
+
+/** Launches a configuration under Debug, the same call the plugin makes for its own second tab. */
+fun Driver.debugConfiguration(settings: RunnerAndConfigurationSettingsRef) {
+    utility(ProgramRunnerUtilRef::class).executeConfiguration(
+        settings,
+        utility(DefaultDebugExecutorRef::class).getDebugExecutorInstance()
+    )
+}

--- a/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugChannel.java
+++ b/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugChannel.java
@@ -101,6 +101,13 @@ public final class KarateDebugChannel implements AutoCloseable {
    */
   private volatile boolean breakpointsKnown;
   /**
+   * Whether the handshake is also waiting for the opt-in JVM debugger to attach. A Java breakpoint
+   * only binds once the debugger is attached, so releasing the run first would let the steps that
+   * load the user's classes go by unwatched. {@link #holdForJvmDebugger} takes its own backstop:
+   * something that never attaches must cost the user their Java breakpoints, never the run.
+   */
+  private volatile boolean waitingForJvmDebugger;
+  /**
    * Settings the session asked for before the agent existed. Anything sent while there is no socket
    * is dropped, and the session starts while the test JVM is still booting, so what the session wants
    * is held here and sent the moment it connects - the same reason the breakpoint set is.
@@ -157,6 +164,45 @@ public final class KarateDebugChannel implements AutoCloseable {
     breakpoints = List.copyOf(updated);
     breakpointsKnown = true;
     sendBreakpoints();
+  }
+
+  /**
+   * Holds the handshake until {@link #jvmDebuggerAttached()}, for a run that opted into the JVM
+   * debugger as well. The agent does not run a step until it has the breakpoint set, so this is what
+   * keeps the first step from running before the Java side is watching.
+   *
+   * @param timeoutMillis how long to hold before giving up and releasing the run anyway. Must be
+   *     comfortably under the agent's own handshake timeout: past that the agent starts without a
+   *     breakpoint set at all, so a JVM debugger that never arrives would cost the user their
+   *     <i>Karate</i> breakpoints too.
+   */
+  public void holdForJvmDebugger(long timeoutMillis) {
+    waitingForJvmDebugger = true;
+    // A plain thread rather than the application's scheduler, for the same reason the reader is one:
+    // this class stays runnable outside an IDE so it can be tested against a socket.
+    Thread backstop = new Thread(() -> {
+      try {
+        Thread.sleep(timeoutMillis);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      if (waitingForJvmDebugger) {
+        LOG.warn("The JVM debugger did not attach within " + timeoutMillis
+          + "ms; starting the run without it");
+        jvmDebuggerAttached();
+      }
+    }, "uppercut-jvm-debugger-wait");
+    backstop.setDaemon(true);
+    backstop.start();
+  }
+
+  /** The JVM debugger is attached (or never will be): let the agent have the breakpoint set. */
+  public void jvmDebuggerAttached() {
+    if (waitingForJvmDebugger) {
+      waitingForJvmDebugger = false;
+      sendBreakpoints();
+    }
   }
 
   /**
@@ -324,7 +370,7 @@ public final class KarateDebugChannel implements AutoCloseable {
   }
 
   private void sendBreakpoints() {
-    if (out == null || !breakpointsKnown) {
+    if (out == null || !breakpointsKnown || waitingForJvmDebugger) {
       return;
     }
     List<String> commands = new ArrayList<>();

--- a/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugRunner.java
+++ b/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugRunner.java
@@ -28,6 +28,10 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>Registered ahead of the platform's own debug runner, which would otherwise claim this
  * configuration and attach JDWP.</p>
+
+ * <p>A run <i>can</i> ask for the JVM debugger as well - see {@link KarateJvmDebuggerAttach} - in
+ * which case it arrives as a second tab, from an ordinary Remote JVM Debug configuration, and this
+ * runner still owns the first one.</p>
  */
 public class KarateDebugRunner extends GenericProgramRunner<RunnerSettings> {
 
@@ -57,8 +61,15 @@ public class KarateDebugRunner extends GenericProgramRunner<RunnerSettings> {
           // Launching here, inside the starter, is what puts the test tree and the debugger in one
           // tab: the session adopts the run's own console and process rather than opening its own.
           ExecutionResult result = state.execute(environment.getExecutor(), KarateDebugRunner.this);
-          KarateDebugChannel channel = state instanceof KarateRunConfiguration.DebugChannelHolder holder
-            ? holder.debugChannel() : null;
+          KarateRunConfiguration.DebugChannelHolder holder =
+            state instanceof KarateRunConfiguration.DebugChannelHolder h ? h : null;
+          KarateDebugChannel channel = holder == null ? null : holder.debugChannel();
+          // Before the process is returned, so the session's breakpoints - and with them the agent's
+          // handshake - come after the attach has been asked for rather than racing it.
+          if (holder != null && holder.jvmDebugPort() > 0) {
+            KarateJvmDebuggerAttach.attach(environment.getProject(), holder.jvmDebugPort(), channel,
+              result.getProcessHandler());
+          }
           KarateDebugProcess process = new KarateDebugProcess(session, channel, result);
           if (channel != null) {
             channel.setListener(process);

--- a/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateJvmDebuggerAttach.java
+++ b/src/main/java/com/rankweis/uppercut/karate/debugging/agent/KarateJvmDebuggerAttach.java
@@ -1,0 +1,119 @@
+package com.rankweis.uppercut.karate.debugging.agent;
+
+import com.intellij.execution.ProgramRunnerUtil;
+import com.intellij.execution.RunManager;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.remote.RemoteConfiguration;
+import com.intellij.execution.remote.RemoteConfigurationType;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.util.messages.MessageBusConnection;
+import com.intellij.xdebugger.XDebugProcess;
+import com.intellij.xdebugger.XDebuggerManager;
+import com.intellij.xdebugger.XDebuggerManagerListener;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The opt-in second debugger: an ordinary <b>Remote JVM Debug</b> session pointed at the JDWP port
+ * the test JVM was launched with.
+ *
+ * <p>Karate has no user-written step definitions, so the JVM debugger is not how you stop on a step -
+ * the Karate session does that on both majors. It is for the two things that session cannot reach:
+ * Java a feature calls through {@code Java.type}, and karate-core itself.</p>
+ *
+ * <p><b>Why the platform's own configuration rather than attaching one here.</b>
+ * {@link KarateDebugRunner} already claims the Debug executor ahead of the platform's debug runner,
+ * so there is no second runner to hand this to; the alternative is
+ * {@code DebuggerManagerEx.attachVirtualMachine} and {@code RemoteConnectionBuilder}, which live in
+ * {@code com.intellij.debugger.impl}. Running the stock configuration keeps this to public API, and
+ * gives the user a real second tab with the full Java debugger - stopping or detaching it leaves the
+ * Karate run going.</p>
+ *
+ * <p><b>The two tabs share one JVM's threads.</b> A Java breakpoint suspends all of them by default,
+ * and one of them serves the Karate tab: while the Java tab holds the VM, the Karate tab answers
+ * nothing. Nothing is lost - commands sent meanwhile are acted on when the VM resumes - but this is
+ * why the JVM debugger is opt-in rather than always on. See {@code docs/DEBUGGER.md}, phase 6.</p>
+ */
+public final class KarateJvmDebuggerAttach {
+
+  private static final Logger LOG = Logger.getInstance(KarateJvmDebuggerAttach.class);
+
+  private KarateJvmDebuggerAttach() {
+  }
+
+  /**
+   * Starts a Remote JVM Debug session against {@code port} and tells {@code channel} when it is
+   * attached, so the run's first step waits for it.
+   *
+   * @param process the test JVM, so the attach is abandoned if the run dies before it starts
+   */
+  public static void attach(@NotNull Project project, int port, @Nullable KarateDebugChannel channel,
+    @Nullable ProcessHandler process) {
+    RunnerAndConfigurationSettings settings = RunManager.getInstance(project)
+      .createConfiguration("Karate JVM debugger",
+        RemoteConfigurationType.getInstance().getConfigurationFactories()[0]);
+    RemoteConfiguration remote = (RemoteConfiguration) settings.getConfiguration();
+    remote.USE_SOCKET_TRANSPORT = true;
+    // The test JVM was launched server=y, so the IDE is the one attaching.
+    remote.SERVER_MODE = false;
+    remote.HOST = "localhost";
+    remote.PORT = String.valueOf(port);
+    settings.setTemporary(true);
+
+    if (channel != null) {
+      releaseChannelWhenAttached(project, remote.PORT, channel);
+      if (process != null) {
+        // A run that dies before the debugger attaches would otherwise hold the handshake for its
+        // full timeout, for a JVM that is already gone.
+        process.addProcessListener(new ProcessListener() {
+          @Override public void processTerminated(@NotNull ProcessEvent event) {
+            channel.jvmDebuggerAttached();
+          }
+        });
+      }
+    }
+
+    // executeConfiguration is an EDT call, and this runs on whichever thread started the process.
+    ApplicationManager.getApplication().invokeLater(() -> {
+      try {
+        ProgramRunnerUtil.executeConfiguration(settings, DefaultDebugExecutor.getDebugExecutorInstance());
+      } catch (RuntimeException e) {
+        LOG.warn("Could not start the JVM debugger on port " + port, e);
+        if (channel != null) {
+          channel.jvmDebuggerAttached();
+        }
+      }
+    });
+  }
+
+  /**
+   * Releases the Karate handshake once the remote session is up. {@code processStarted} fires after
+   * the platform has the connection, which is the closest thing to "the JVM debugger is watching"
+   * the platform offers a listener.
+   *
+   * <p>Matched on the port rather than on the configuration instance: the platform is free to run a
+   * copy of the settings it was handed, and identity that quietly stops matching would leave every
+   * such run waiting out the hold's full timeout before its first step. The port is this launch's
+   * alone - nothing else is listening on it.</p>
+   */
+  private static void releaseChannelWhenAttached(@NotNull Project project, @NotNull String port,
+    @NotNull KarateDebugChannel channel) {
+    MessageBusConnection connection = project.getMessageBus().connect();
+    connection.subscribe(XDebuggerManager.TOPIC, new XDebuggerManagerListener() {
+      @Override public void processStarted(@NotNull XDebugProcess started) {
+        if (started.getSession().getRunProfile() instanceof RemoteConfiguration attached
+          && port.equals(attached.PORT)) {
+          channel.jvmDebuggerAttached();
+          Disposer.dispose(connection);
+        }
+      }
+    });
+  }
+}

--- a/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java
+++ b/src/main/java/com/rankweis/uppercut/karate/run/KarateRunConfiguration.java
@@ -46,6 +46,8 @@ import com.rankweis.uppercut.settings.KarateSettingsState;
 import com.rankweis.uppercut.testrunner.KarateTestRunner;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -87,6 +89,13 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
   @Getter @Setter private String featureName;
   @Getter @Setter private String scenarioName;
   @Getter @Setter private String debugPort;
+  /**
+   * Opt-in: attach the JVM debugger to the test JVM as well, in its own tab. Karate has no
+   * user-written step definitions, so this is for the two things the Karate debugger cannot reach -
+   * Java a feature calls through {@code Java.type}, and karate-core itself. Off by default, because
+   * a Java breakpoint suspends every thread in the JVM, including the one serving the Karate tab.
+   */
+  @Getter @Setter private boolean attachJvmDebugger = false;
   @Getter @Setter private String tag;
   @Getter @Setter private String path;
   @Getter @Setter private PreferredTest preferredTest = PreferredTest.WHOLE_FILE;
@@ -128,6 +137,13 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
   public interface DebugChannelHolder {
 
     @Nullable KarateDebugChannel debugChannel();
+
+    /**
+     * The JDWP port this launch opened for the opt-in JVM debugger, or 0 when it was not asked for.
+     * Like the channel's port it is chosen while the command line is built, because that is when it
+     * has to be written into the test JVM's arguments.
+     */
+    int jvmDebugPort();
   }
 
   @Override
@@ -140,10 +156,17 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
        * read back by {@code KarateDebugRunner} once there is a process to attach a session to.
        */
       private KarateDebugChannel debugChannel;
+      /** The JDWP port for the opt-in JVM debugger, or 0 when this run did not ask for one. */
+      private int jvmDebugPort;
 
       @Override
       public @Nullable KarateDebugChannel debugChannel() {
         return debugChannel;
+      }
+
+      @Override
+      public int jvmDebugPort() {
+        return jvmDebugPort;
       }
 
       @Override
@@ -276,6 +299,9 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
             log.warn("Could not open the Karate debug channel; feature-file breakpoints are off", e);
             debugChannel = null;
           }
+          if (isAttachJvmDebugger()) {
+            jvmDebugPort = openJvmDebugPort(params, debugChannel);
+          }
         }
 
         return params;
@@ -305,6 +331,39 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
     };
   }
 
+
+  /**
+   * How long the run's first step waits for the opt-in JVM debugger to attach. Well under the agent's
+   * own 15s handshake timeout, past which it starts with no breakpoint set at all - a JVM debugger
+   * that never arrives must not cost the user their Karate breakpoints as well.
+   */
+  private static final long JVM_DEBUGGER_ATTACH_TIMEOUT_MILLIS = 8_000L;
+
+  /**
+   * Opens a JDWP port on the test JVM for the opt-in JVM debugger, and holds the Karate handshake
+   * until it attaches. Returns the port, or 0 if none could be opened - in which case the run goes
+   * ahead with the Karate debugger alone.
+   */
+  private static int openJvmDebugPort(@NotNull JavaParameters params,
+    @Nullable KarateDebugChannel channel) {
+    int port;
+    try (ServerSocket free = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+      port = free.getLocalPort();
+    } catch (IOException e) {
+      log.warn("Could not find a free port for the JVM debugger; running without it", e);
+      return 0;
+    }
+    // server=y,suspend=n. suspend=y would guarantee nothing runs before the attach, at the price of
+    // a test JVM parked forever if the attach never happens - the one outcome this debugger goes out
+    // of its way to avoid. The Karate handshake gives the same guarantee with a timeout that ends in
+    // a run rather than a hang, so the JVM itself never has to wait.
+    params.getVMParametersList().add(
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:" + port);
+    if (channel != null) {
+      channel.holdForJvmDebugger(JVM_DEBUGGER_ATTACH_TIMEOUT_MILLIS);
+    }
+    return port;
+  }
 
   /** Whether this configuration asked for more than one scenario at a time; blank or junk means no. */
   private boolean parallelismAboveOne() {
@@ -494,6 +553,7 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
     element.setAttribute("featureName", Optional.ofNullable(featureName).orElse(""));
     element.setAttribute("scenarioName", Optional.ofNullable(scenarioName).orElse(""));
     element.setAttribute("debugPort", Optional.ofNullable(debugPort).orElse(""));
+    element.setAttribute("attachJvmDebugger", String.valueOf(attachJvmDebugger));
     element.setAttribute("tag", Optional.ofNullable(tag).orElse(""));
     element.setAttribute("path", Optional.ofNullable(path).orElse(""));
     element.setAttribute("preferredTest", preferredTest.name);
@@ -513,6 +573,7 @@ public class KarateRunConfiguration extends ApplicationConfiguration implements 
     featureName = element.getAttributeValue("featureName");
     scenarioName = element.getAttributeValue("scenarioName");
     debugPort = element.getAttributeValue("debugPort");
+    attachJvmDebugger = Boolean.parseBoolean(element.getAttributeValue("attachJvmDebugger"));
     tag = element.getAttributeValue("tag");
     path = element.getAttributeValue("path");
     preferredTest =

--- a/src/main/java/com/rankweis/uppercut/karate/run/KarateSettingsEditor.java
+++ b/src/main/java/com/rankweis/uppercut/karate/run/KarateSettingsEditor.java
@@ -8,6 +8,7 @@ import com.intellij.execution.ui.SettingsEditorFragment;
 import com.intellij.openapi.externalSystem.service.execution.configuration.fragments.SettingsEditorLabeledComponent;
 import com.intellij.openapi.project.Project;
 import java.util.List;
+import javax.swing.JCheckBox;
 import javax.swing.JTextField;
 
 public class KarateSettingsEditor extends JavaSettingsEditorBase<KarateRunConfiguration> {
@@ -24,6 +25,7 @@ public class KarateSettingsEditor extends JavaSettingsEditorBase<KarateRunConfig
     fragments.add(getParallelism());
     fragments.add(getEnv());
     fragments.add(getDebugPort());
+    fragments.add(getAttachJvmDebugger());
   }
 
   private SettingsEditorFragment<KarateRunConfiguration,
@@ -70,9 +72,24 @@ public class KarateSettingsEditor extends JavaSettingsEditorBase<KarateRunConfig
   private SettingsEditorFragment<KarateRunConfiguration, SettingsEditorLabeledComponent<JTextField>> getDebugPort() {
     JTextField textField = new JTextField();
     return new SettingsEditorFragment<>("karate.test.debugPort", "Debug port", "Tests",
-      new SettingsEditorLabeledComponent<>("Debug port (will suspend if set)", textField),
+      new SettingsEditorLabeledComponent<>("Debug port", textField),
       6, (settings, component) -> component.getComponent().setText(settings.getDebugPort()),
       (settings, component) -> settings.setDebugPort(component.getComponent().getText()),
+      x -> true
+    );
+  }
+
+  /**
+   * Off by default. A Java breakpoint suspends every thread in the test JVM, including the one
+   * serving the Karate tab, so the second debugger is worth having only when there is Java to stop
+   * in - see the troubleshooting page.
+   */
+  private SettingsEditorFragment<KarateRunConfiguration, JCheckBox> getAttachJvmDebugger() {
+    JCheckBox checkBox = new JCheckBox("Attach the JVM debugger too (separate tab)");
+    return new SettingsEditorFragment<>("karate.test.attachJvmDebugger", "JVM debugger", "Test Options",
+      checkBox,
+      8, (settings, component) -> component.setSelected(settings.isAttachJvmDebugger()),
+      (settings, component) -> settings.setAttachJvmDebugger(component.isSelected()),
       x -> true
     );
   }

--- a/src/test/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugChannelTest.java
+++ b/src/test/java/com/rankweis/uppercut/karate/debugging/agent/KarateDebugChannelTest.java
@@ -160,6 +160,41 @@ public class KarateDebugChannelTest {
   }
 
   @Test
+  public void holdsTheHandshakeUntilTheJvmDebuggerAttaches() throws Exception {
+    // A java breakpoint only binds once the debugger is attached, so a run that opted into the JVM
+    // debugger must not let its first step go by before then.
+    channel = new KarateDebugChannel();
+    channel.start();
+    channel.holdForJvmDebugger(60_000);
+    BufferedReader fromChannel = connectAgent();
+    channel.setBreakpoints(List.of(new KarateDebugChannel.Breakpoint("/repo/a.feature", 4)));
+
+    agent.setSoTimeout(500);
+    assertThrows(SocketTimeoutException.class, fromChannel::readLine);
+
+    agent.setSoTimeout(TIMEOUT_SECONDS * 1000);
+    channel.jvmDebuggerAttached();
+    assertEquals(DebugProtocol.CLEAR, fromChannel.readLine());
+    assertEquals(DebugProtocol.breakpointCommand("/repo/a.feature", 4), fromChannel.readLine());
+    assertEquals(DebugProtocol.BREAKPOINTS_END, fromChannel.readLine());
+  }
+
+  @Test
+  public void startsTheRunAnywayWhenTheJvmDebuggerNeverAttaches() throws Exception {
+    // Failing open matters more here than anywhere: holding past the agent's own handshake timeout
+    // would start the suite with no breakpoint set at all, losing the karate breakpoints as well.
+    channel = new KarateDebugChannel();
+    channel.start();
+    channel.holdForJvmDebugger(200);
+    BufferedReader fromChannel = connectAgent();
+    channel.setBreakpoints(List.of(new KarateDebugChannel.Breakpoint("/repo/a.feature", 4)));
+
+    assertEquals(DebugProtocol.CLEAR, fromChannel.readLine());
+    assertEquals(DebugProtocol.breakpointCommand("/repo/a.feature", 4), fromChannel.readLine());
+    assertEquals(DebugProtocol.BREAKPOINTS_END, fromChannel.readLine());
+  }
+
+  @Test
   public void completesTheHandshakeOnceTheSessionHasSaidThereAreNoBreakpoints() throws Exception {
     // BREAKPOINTS_END is also the agent's handshake, so an empty set still has to be sent - the run
     // would otherwise wait out the agent's whole timeout before starting.

--- a/src/test/java/com/rankweis/uppercut/karate/run/KarateRunConfigurationProducerTest.java
+++ b/src/test/java/com/rankweis/uppercut/karate/run/KarateRunConfigurationProducerTest.java
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import java.util.List;
+import org.jdom.Element;
 
 /**
  * The run configuration offered on a folder, and whether it displaces the build tool's own
@@ -39,6 +40,23 @@ public class KarateRunConfigurationProducerTest extends BasePlatformTestCase {
     // the folder still gets a (recursive) Karate run, but it must not push the JUnit/Gradle one out
     assertNotNull(fromContext);
     assertFalse(new KarateRunConfigurationProducer().shouldReplace(fromContext, fromContext));
+  }
+
+  public void testTheJvmDebuggerOptInSurvivesSaveAndReload() {
+    // A run configuration setting that does not round-trip is silently forgotten the next time the
+    // project opens, and the user is left with a checkbox that does nothing every second session.
+    KarateRunConfiguration saved = new KarateRunConfiguration(getProject(),
+        new KarateConfigurationType().getConfigurationFactories()[0], "karate");
+    assertFalse("the JVM debugger is opt-in, so it must be off out of the box",
+      saved.isAttachJvmDebugger());
+    saved.setAttachJvmDebugger(true);
+    Element element = new Element("configuration");
+    saved.writeExternal(element);
+
+    KarateRunConfiguration reloaded = new KarateRunConfiguration(getProject(),
+        new KarateConfigurationType().getConfigurationFactories()[0], "karate");
+    reloaded.readExternal(element);
+    assertTrue(reloaded.isAttachJvmDebugger());
   }
 
   public void testTagRunsScanTheModuleSourceRootsNotTheModuleDirectory() {

--- a/testProjects/karate-versions/v1/build.gradle.kts
+++ b/testProjects/karate-versions/v1/build.gradle.kts
@@ -29,6 +29,7 @@ sourceSets {
             // not - and a fixture that will not compile there fails the whole suite.
             if (!runnerAvailable) {
                 exclude("**/DebugHarness.java")
+                exclude("**/JdwpClashProbe.java")
             }
         }
         resources {
@@ -64,6 +65,25 @@ tasks.register<JavaExec>("debugHarness") {
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass = "sample.DebugHarness"
     for (name in listOf("pauseLine", "pauseSeconds", "moveTo", "stepAfterPause", "pauseOnFailure", "feature", "condition")) {
+        if (project.hasProperty(name)) {
+            systemProperty(name, project.property(name).toString())
+        }
+    }
+    doFirst {
+        require(runnerClasses.isDirectory) {
+            "Run ./gradlew :KarateTestRunner:classes in the root project first - $runnerClasses is missing"
+        }
+    }
+    isIgnoreExitValue = true
+}
+
+// The Karate 1 half of the phase 6 spike in docs/DEBUGGER.md.
+//   ./gradlew :KarateTestRunner:classes
+//   ../../gradlew -p testProjects/karate-versions :v1:jdwpClash
+tasks.register<JavaExec>("jdwpClash") {
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass = "sample.JdwpClashProbe"
+    for (name in listOf("parallelism")) {
         if (project.hasProperty(name)) {
             systemProperty(name, project.property(name).toString())
         }

--- a/testProjects/karate-versions/v1/src/test/java/sample/Helper.java
+++ b/testProjects/karate-versions/v1/src/test/java/sample/Helper.java
@@ -1,0 +1,15 @@
+package sample;
+
+/**
+ * Java called from a feature through {@code Java.type}, so a JDWP breakpoint has somewhere to land
+ * that is the user's own code rather than karate-core's. Used by {@code JdwpClashProbe}: this is the
+ * one thing an opt-in JVM debugger on a Karate run would be for.
+ */
+public class Helper {
+
+  public static int compute(int seed) {
+    int doubled = seed * 2;
+    System.out.println("[HELPER] compute(" + seed + ") on " + Thread.currentThread());
+    return doubled + 1;
+  }
+}

--- a/testProjects/karate-versions/v1/src/test/java/sample/JdwpClashProbe.java
+++ b/testProjects/karate-versions/v1/src/test/java/sample/JdwpClashProbe.java
@@ -1,0 +1,374 @@
+package sample;
+
+import com.rankweis.uppercut.testrunner.KarateTestRunner;
+import com.sun.jdi.Bootstrap;
+import com.sun.jdi.ReferenceType;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.connect.AttachingConnector;
+import com.sun.jdi.connect.Connector;
+import com.sun.jdi.event.BreakpointEvent;
+import com.sun.jdi.event.ClassPrepareEvent;
+import com.sun.jdi.event.Event;
+import com.sun.jdi.event.EventSet;
+import com.sun.jdi.event.VMDeathEvent;
+import com.sun.jdi.event.VMDisconnectEvent;
+import com.sun.jdi.request.BreakpointRequest;
+import com.sun.jdi.request.ClassPrepareRequest;
+import com.sun.jdi.request.EventRequest;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Does an opt-in JVM debugger get along with the Karate debug agent, or do they fight over the same
+ * JVM? The phase 6 spike for docs/DEBUGGER.md.
+ *
+ * <p>A Karate run currently attaches no JVM debugger at all. Bringing one back as an opt-in second
+ * tab is cheap to wire, so the only question worth spiking is what happens when both debuggers are
+ * live in one JVM - because they are not independent: a Java breakpoint's default suspend policy is
+ * <b>all threads</b>, and one of those threads is the agent's socket reader.</p>
+ *
+ * <p>The Karate 1 twin of the v2 probe: same experiments, {@code RuntimeHook.beforeStep} and platform
+ * threads instead of the v2 interceptor and virtual ones.</p>
+ *
+ * <p>Two processes. The parent is a stand-in for the IDE with both tabs open: it listens on the
+ * Karate debug channel <i>and</i> attaches JDI to the child, exactly as the two sessions would. The
+ * child is a real Karate suite under the real agent, launched with JDWP the way an opt-in Debug run
+ * would launch it.</p>
+ *
+ * <pre>
+ *   ./gradlew :KarateTestRunner:classes
+ *   ../../gradlew -p testProjects/karate-versions :v1:jdwpClash
+ *   ../../gradlew -p testProjects/karate-versions :v1:jdwpClash -Pparallelism=2
+ * </pre>
+ *
+ * <p>The sequence: pause the scenario on the step that calls Java, prove the Karate channel answers,
+ * then suspend the whole VM the way a Java breakpoint would and ask the same question again. Then
+ * release the VM, let the run reach the real Java breakpoint, and see which thread it lands on.</p>
+ */
+public class JdwpClashProbe {
+
+  private static final Pattern THREAD = Pattern.compile("\"thread\":\"([^\"]*)\"");
+  /** The step that calls into sample.Helper; Karate pauses before it, so Java has not run yet. */
+  private static final int JAVA_CALL_LINE = 6;
+
+  private final LinkedBlockingQueue<String> fromAgent = new LinkedBlockingQueue<>();
+  private final CountDownLatch agentConnected = new CountDownLatch(1);
+  private volatile PrintWriter toAgent;
+
+  public static void main(String[] args) throws Exception {
+    if (args.length > 0 && "child".equals(args[0])) {
+      child(Integer.parseInt(args[1]), args[2], args[3]);
+      return;
+    }
+    new JdwpClashProbe().parent();
+  }
+
+  // ---------------------------------------------------------------- child
+
+  /** The test JVM: a real Karate suite with the real agent, and JDWP open for the parent. */
+  private static void child(int idePort, String feature, String parallelism) throws Exception {
+    KarateTestRunner.main(new String[]{
+      "--testname", "file:" + feature,
+      // Karate 1 relativizes the feature path against the working dir, so both must be absolute.
+      "--working-dir", Path.of(".").toAbsolutePath().normalize().toString(),
+      "--parallelism", parallelism,
+      "--debug-port", String.valueOf(idePort)});
+  }
+
+  // --------------------------------------------------------------- parent
+
+  private void parent() throws Exception {
+    Path feature = Path.of("src/test/java/sample/javacall.feature").toAbsolutePath();
+    String parallelism = System.getProperty("parallelism", "1");
+
+    try (ServerSocket ide = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+      ServerSocket free = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+      int jdwpPort = free.getLocalPort();
+      free.close();
+
+      Thread channel = new Thread(() -> serveChannel(ide, feature), "fake-ide");
+      channel.setDaemon(true);
+      channel.start();
+
+      log("launching the test JVM with JDWP on " + jdwpPort + ", karate channel on "
+        + ide.getLocalPort() + ", parallelism " + parallelism);
+      Process child = launchChild(ide.getLocalPort(), feature, jdwpPort, parallelism);
+
+      VirtualMachine vm = attach(jdwpPort);
+      log("JDI attached: " + vm.name() + " " + vm.version());
+      log("virtual threads visible to JDI at attach: "
+        + vm.allThreads().stream().filter(t -> t.name().startsWith("VirtualThread")).count()
+        + " of " + vm.allThreads().size() + " threads");
+
+      BreakpointHits hits = new BreakpointHits();
+      armHelperBreakpoint(vm, hits);
+      // suspend=y means the child has run nothing yet; let it go now that the request is armed.
+      vm.resume();
+
+      runExperiments(vm, hits);
+
+      child.waitFor(60, TimeUnit.SECONDS);
+      log("child exited with " + (child.isAlive() ? "(still alive)" : child.exitValue()));
+    }
+  }
+
+  private void runExperiments(VirtualMachine vm, BreakpointHits hits) throws Exception {
+    if (!agentConnected.await(30, TimeUnit.SECONDS)) {
+      log("FAIL - the agent never connected to the karate channel");
+      return;
+    }
+    log("experiment 0: the agent connected while JDWP was attached, so the two do not "
+      + "exclude each other at startup");
+
+    String thread = awaitPaused(30_000);
+    if (thread == null) {
+      log("FAIL - the run never paused on the karate breakpoint");
+      return;
+    }
+    log("karate paused on " + thread + " at javacall.feature:" + JAVA_CALL_LINE);
+
+    log("experiment 1: karate channel with the VM running");
+    report(askVariables(thread, 1, 5_000));
+
+    log("experiment 2: karate channel while the VM is suspended, which is what a java "
+      + "breakpoint with the default suspend policy does");
+    vm.suspend();
+    log("vm.suspend() returned; suspendCount on the paused scenario thread: "
+      + suspendCount(vm, thread));
+    long blocked = askVariables(thread, 2, 5_000);
+    report(blocked);
+
+    log("experiment 3: does a karate resume issued during the suspension survive it");
+    toAgent.println("RESUME " + thread);
+    String duringSuspension = fromAgent.poll(3, TimeUnit.SECONDS);
+    log("anything from the agent in 3s of suspension: " + duringSuspension);
+
+    long resumedAt = System.currentTimeMillis();
+    vm.resume();
+    String afterResume = fromAgent.poll(10, TimeUnit.SECONDS);
+    log("first line after vm.resume(), " + (System.currentTimeMillis() - resumedAt) + "ms later: "
+      + afterResume);
+
+    log("experiment 4: the java breakpoint in the user's own code");
+    if (hits.latch.await(30, TimeUnit.SECONDS)) {
+      log("java breakpoint hit on thread: " + hits.threadName
+        + " (virtual: " + hits.virtualThread + ")");
+      log("karate channel while stopped at the java breakpoint:");
+      report(askVariables(thread, 4, 5_000));
+      hits.release();
+      log("released the java breakpoint");
+    } else {
+      log("FAIL - the java breakpoint in sample.Helper never hit"
+        + (hits.armed ? "" : " (it was never armed - Helper was not prepared)"));
+    }
+  }
+
+  /** Sends a VARIABLES request and returns how long the reply took, or -1 if none came. */
+  private long askVariables(String thread, int id, long timeoutMillis) throws InterruptedException {
+    fromAgent.clear();
+    long start = System.currentTimeMillis();
+    toAgent.println("VARIABLES " + thread + " " + id);
+    String reply = fromAgent.poll(timeoutMillis, TimeUnit.MILLISECONDS);
+    return reply == null ? -1 : System.currentTimeMillis() - start;
+  }
+
+  private void report(long millis) {
+    log(millis < 0 ? "  -> no reply: the channel is frozen" : "  -> replied in " + millis + "ms");
+  }
+
+  private String awaitPaused(long timeoutMillis) throws InterruptedException {
+    long deadline = System.currentTimeMillis() + timeoutMillis;
+    while (System.currentTimeMillis() < deadline) {
+      String message = fromAgent.poll(deadline - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      if (message == null) {
+        return null;
+      }
+      if (message.startsWith("EVENT PAUSED ")) {
+        Matcher matcher = THREAD.matcher(message);
+        return matcher.find() ? matcher.group(1) : "";
+      }
+    }
+    return null;
+  }
+
+  // -------------------------------------------------------------- plumbing
+
+  private Process launchChild(int idePort, Path feature, int jdwpPort, String parallelism)
+    throws IOException {
+    List<String> command = List.of(
+      Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=127.0.0.1:" + jdwpPort,
+      "-cp", System.getProperty("java.class.path"),
+      JdwpClashProbe.class.getName(), "child", String.valueOf(idePort), feature.toString(),
+      parallelism);
+    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    Thread pump = new Thread(() -> pump(process.getInputStream()), "child-output");
+    pump.setDaemon(true);
+    pump.start();
+    return process;
+  }
+
+  private static void pump(InputStream stream) {
+    try (BufferedReader reader = new BufferedReader(
+      new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.startsWith("<<UPPERCUT-V2>> SUITE_EXIT") || line.startsWith("<<UPPERCUT-V2>> FEATURE_EXIT")) {
+          System.out.println("[child] " + line.substring(0, Math.min(120, line.length())) + " ...");
+        } else {
+          System.out.println("[child] " + line);
+        }
+      }
+    } catch (IOException e) {
+      // the child ended
+    }
+  }
+
+  private static VirtualMachine attach(int port) throws Exception {
+    AttachingConnector connector = Bootstrap.virtualMachineManager().attachingConnectors().stream()
+      .filter(c -> "com.sun.jdi.SocketAttach".equals(c.name()))
+      .findFirst().orElseThrow(() -> new IllegalStateException("no SocketAttach connector"));
+    Map<String, Connector.Argument> arguments = connector.defaultArguments();
+    arguments.get("hostname").setValue("127.0.0.1");
+    arguments.get("port").setValue(String.valueOf(port));
+    IllegalStateException last = new IllegalStateException("could not attach");
+    for (int attempt = 0; attempt < 40; attempt++) {
+      try {
+        return connector.attach(arguments);
+      } catch (IOException e) {
+        Thread.sleep(250);
+      }
+    }
+    throw last;
+  }
+
+  /** What the JDI event thread records about the breakpoint in sample.Helper. */
+  private static final class BreakpointHits {
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile boolean armed;
+    private volatile String threadName;
+    private volatile boolean virtualThread;
+    private volatile EventSet held;
+
+    private void release() {
+      EventSet set = held;
+      if (set != null) {
+        set.resume();
+      }
+    }
+  }
+
+  /**
+   * Arms a breakpoint on {@code Helper.compute} with the default suspend-all policy - the point of
+   * the probe is what the IDE's default does, not what a careful user could choose instead.
+   */
+  private void armHelperBreakpoint(VirtualMachine vm, BreakpointHits hits) {
+    ClassPrepareRequest prepare = vm.eventRequestManager().createClassPrepareRequest();
+    prepare.addClassFilter("sample.Helper");
+    prepare.setSuspendPolicy(EventRequest.SUSPEND_ALL);
+    prepare.enable();
+
+    Thread events = new Thread(() -> {
+      try {
+        while (true) {
+          EventSet set = vm.eventQueue().remove();
+          boolean hold = false;
+          for (Event event : set) {
+            if (event instanceof ClassPrepareEvent prepared) {
+              ReferenceType type = prepared.referenceType();
+              BreakpointRequest breakpoint = vm.eventRequestManager()
+                .createBreakpointRequest(type.methodsByName("compute").get(0).location());
+              breakpoint.setSuspendPolicy(EventRequest.SUSPEND_ALL);
+              breakpoint.enable();
+              hits.armed = true;
+              log("armed a java breakpoint on sample.Helper.compute, suspend policy ALL");
+            } else if (event instanceof BreakpointEvent stopped) {
+              ThreadReference thread = stopped.thread();
+              hits.threadName = thread.name() + " #" + thread.uniqueID();
+              hits.virtualThread = isVirtual(thread);
+              hits.held = set;
+              hits.latch.countDown();
+              hold = true;
+            } else if (event instanceof VMDeathEvent || event instanceof VMDisconnectEvent) {
+              return;
+            }
+          }
+          if (!hold) {
+            set.resume();
+          }
+        }
+      } catch (Exception e) {
+        log("jdi event loop ended: " + e);
+      }
+    }, "jdi-events");
+    events.setDaemon(true);
+    events.start();
+  }
+
+  private static boolean isVirtual(ThreadReference thread) {
+    try {
+      return (boolean) ThreadReference.class.getMethod("isVirtual").invoke(thread);
+    } catch (ReflectiveOperationException e) {
+      return thread.name().startsWith("VirtualThread");
+    }
+  }
+
+  private static String suspendCount(VirtualMachine vm, String threadKey) {
+    try {
+      return vm.allThreads().stream()
+        .filter(t -> threadKey.equals(t.name()))
+        .findFirst()
+        .map(t -> String.valueOf(t.suspendCount()))
+        .orElse("(thread " + threadKey + " not visible to JDI)");
+    } catch (Exception e) {
+      return "(" + e + ")";
+    }
+  }
+
+  /** The IDE's karate tab: one breakpoint on the step that calls Java, then relay everything. */
+  private void serveChannel(ServerSocket server, Path feature) {
+    try (Socket socket = server.accept();
+      BufferedReader in = new BufferedReader(
+        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+      PrintWriter out = new PrintWriter(socket.getOutputStream(), true)) {
+      toAgent = out;
+      out.println("PAUSE_ON_FAILURE false");
+      out.println("CLEAR");
+      out.println("BREAKPOINT " + base64(feature.toString()) + " " + JAVA_CALL_LINE);
+      out.println("BREAKPOINTS_END");
+      agentConnected.countDown();
+      String message;
+      while ((message = in.readLine()) != null) {
+        log("← " + (message.length() > 160 ? message.substring(0, 160) + " ..." : message));
+        fromAgent.put(message);
+      }
+    } catch (IOException | InterruptedException e) {
+      log("karate channel ended: " + e);
+    }
+  }
+
+  private static String base64(String value) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void log(String message) {
+    System.out.println("[JDWP-CLASH] " + message);
+  }
+}

--- a/testProjects/karate-versions/v1/src/test/java/sample/javacall.feature
+++ b/testProjects/karate-versions/v1/src/test/java/sample/javacall.feature
@@ -1,0 +1,8 @@
+Feature: java called from a feature - the case an opt-in JVM debugger would serve
+
+  Scenario: call into the user's own Java
+    * def seed = 20
+    * def Helper = Java.type('sample.Helper')
+    * def answer = Helper.compute(seed)
+    * print 'answer is', answer
+    * match answer == 41

--- a/testProjects/karate-versions/v2/build.gradle.kts
+++ b/testProjects/karate-versions/v2/build.gradle.kts
@@ -31,6 +31,7 @@ sourceSets {
             // not - and a fixture that will not compile there fails the whole suite.
             if (!runnerAvailable) {
                 exclude("**/DebugHarness.java")
+                exclude("**/JdwpClashProbe.java")
             }
         }
         resources {
@@ -95,6 +96,27 @@ tasks.register<JavaExec>("debugHarness") {
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass = "sample.DebugHarness"
     for (name in listOf("pauseLine", "pauseSeconds", "moveTo", "stepAfterPause", "pauseOnFailure", "feature", "condition")) {
+        if (project.hasProperty(name)) {
+            systemProperty(name, project.property(name).toString())
+        }
+    }
+    doFirst {
+        require(runnerClasses.isDirectory) {
+            "Run ./gradlew :KarateTestRunner:classes in the root project first - $runnerClasses is missing"
+        }
+    }
+    isIgnoreExitValue = true
+}
+
+// Phase 6 spike for docs/DEBUGGER.md: an opt-in JVM debugger alongside the Karate debug agent, and
+// what the two do to each other in one JVM.
+//   ./gradlew :KarateTestRunner:classes
+//   ../../gradlew -p testProjects/karate-versions :v2:jdwpClash
+//   ../../gradlew -p testProjects/karate-versions :v2:jdwpClash -Pparallelism=2
+tasks.register<JavaExec>("jdwpClash") {
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass = "sample.JdwpClashProbe"
+    for (name in listOf("parallelism")) {
         if (project.hasProperty(name)) {
             systemProperty(name, project.property(name).toString())
         }

--- a/testProjects/karate-versions/v2/src/test/java/sample/Helper.java
+++ b/testProjects/karate-versions/v2/src/test/java/sample/Helper.java
@@ -1,0 +1,15 @@
+package sample;
+
+/**
+ * Java called from a feature through {@code Java.type}, so a JDWP breakpoint has somewhere to land
+ * that is the user's own code rather than karate-core's. Used by {@code JdwpClashProbe}: this is the
+ * one thing an opt-in JVM debugger on a Karate run would be for.
+ */
+public class Helper {
+
+  public static int compute(int seed) {
+    int doubled = seed * 2;
+    System.out.println("[HELPER] compute(" + seed + ") on " + Thread.currentThread());
+    return doubled + 1;
+  }
+}

--- a/testProjects/karate-versions/v2/src/test/java/sample/JdwpClashProbe.java
+++ b/testProjects/karate-versions/v2/src/test/java/sample/JdwpClashProbe.java
@@ -1,0 +1,371 @@
+package sample;
+
+import com.rankweis.uppercut.testrunner.KarateV2TestRunner;
+import com.sun.jdi.Bootstrap;
+import com.sun.jdi.ReferenceType;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.connect.AttachingConnector;
+import com.sun.jdi.connect.Connector;
+import com.sun.jdi.event.BreakpointEvent;
+import com.sun.jdi.event.ClassPrepareEvent;
+import com.sun.jdi.event.Event;
+import com.sun.jdi.event.EventSet;
+import com.sun.jdi.event.VMDeathEvent;
+import com.sun.jdi.event.VMDisconnectEvent;
+import com.sun.jdi.request.BreakpointRequest;
+import com.sun.jdi.request.ClassPrepareRequest;
+import com.sun.jdi.request.EventRequest;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Does an opt-in JVM debugger get along with the Karate debug agent, or do they fight over the same
+ * JVM? The phase 6 spike for docs/DEBUGGER.md.
+ *
+ * <p>A Karate run currently attaches no JVM debugger at all. Bringing one back as an opt-in second
+ * tab is cheap to wire, so the only question worth spiking is what happens when both debuggers are
+ * live in one JVM - because they are not independent: a Java breakpoint's default suspend policy is
+ * <b>all threads</b>, and one of those threads is the agent's socket reader.</p>
+ *
+ * <p>Two processes. The parent is a stand-in for the IDE with both tabs open: it listens on the
+ * Karate debug channel <i>and</i> attaches JDI to the child, exactly as the two sessions would. The
+ * child is a real Karate suite under the real agent, launched with JDWP the way an opt-in Debug run
+ * would launch it.</p>
+ *
+ * <pre>
+ *   ./gradlew :KarateTestRunner:classes
+ *   ../../gradlew -p testProjects/karate-versions :v2:jdwpClash
+ *   ../../gradlew -p testProjects/karate-versions :v2:jdwpClash -Pparallelism=2
+ * </pre>
+ *
+ * <p>The sequence: pause the scenario on the step that calls Java, prove the Karate channel answers,
+ * then suspend the whole VM the way a Java breakpoint would and ask the same question again. Then
+ * release the VM, let the run reach the real Java breakpoint, and see which thread it lands on.</p>
+ */
+public class JdwpClashProbe {
+
+  private static final Pattern THREAD = Pattern.compile("\"thread\":\"([^\"]*)\"");
+  /** The step that calls into sample.Helper; Karate pauses before it, so Java has not run yet. */
+  private static final int JAVA_CALL_LINE = 6;
+
+  private final LinkedBlockingQueue<String> fromAgent = new LinkedBlockingQueue<>();
+  private final CountDownLatch agentConnected = new CountDownLatch(1);
+  private volatile PrintWriter toAgent;
+
+  public static void main(String[] args) throws Exception {
+    if (args.length > 0 && "child".equals(args[0])) {
+      child(Integer.parseInt(args[1]), args[2], args[3]);
+      return;
+    }
+    new JdwpClashProbe().parent();
+  }
+
+  // ---------------------------------------------------------------- child
+
+  /** The test JVM: a real Karate suite with the real agent, and JDWP open for the parent. */
+  private static void child(int idePort, String feature, String parallelism) throws Exception {
+    new KarateV2TestRunner(Map.of(
+      "testname", List.of("file:" + feature),
+      "working-dir", List.of("."),
+      "parallelism", List.of(parallelism),
+      "debug-port", List.of(String.valueOf(idePort))))
+      .doTest();
+  }
+
+  // --------------------------------------------------------------- parent
+
+  private void parent() throws Exception {
+    Path feature = Path.of("src/test/java/sample/javacall.feature").toAbsolutePath();
+    String parallelism = System.getProperty("parallelism", "1");
+
+    try (ServerSocket ide = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+      ServerSocket free = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+      int jdwpPort = free.getLocalPort();
+      free.close();
+
+      Thread channel = new Thread(() -> serveChannel(ide, feature), "fake-ide");
+      channel.setDaemon(true);
+      channel.start();
+
+      log("launching the test JVM with JDWP on " + jdwpPort + ", karate channel on "
+        + ide.getLocalPort() + ", parallelism " + parallelism);
+      Process child = launchChild(ide.getLocalPort(), feature, jdwpPort, parallelism);
+
+      VirtualMachine vm = attach(jdwpPort);
+      log("JDI attached: " + vm.name() + " " + vm.version());
+      log("virtual threads visible to JDI at attach: "
+        + vm.allThreads().stream().filter(t -> t.name().startsWith("VirtualThread")).count()
+        + " of " + vm.allThreads().size() + " threads");
+
+      BreakpointHits hits = new BreakpointHits();
+      armHelperBreakpoint(vm, hits);
+      // suspend=y means the child has run nothing yet; let it go now that the request is armed.
+      vm.resume();
+
+      runExperiments(vm, hits);
+
+      child.waitFor(60, TimeUnit.SECONDS);
+      log("child exited with " + (child.isAlive() ? "(still alive)" : child.exitValue()));
+    }
+  }
+
+  private void runExperiments(VirtualMachine vm, BreakpointHits hits) throws Exception {
+    if (!agentConnected.await(30, TimeUnit.SECONDS)) {
+      log("FAIL - the agent never connected to the karate channel");
+      return;
+    }
+    log("experiment 0: the agent connected while JDWP was attached, so the two do not "
+      + "exclude each other at startup");
+
+    String thread = awaitPaused(30_000);
+    if (thread == null) {
+      log("FAIL - the run never paused on the karate breakpoint");
+      return;
+    }
+    log("karate paused on " + thread + " at javacall.feature:" + JAVA_CALL_LINE);
+
+    log("experiment 1: karate channel with the VM running");
+    report(askVariables(thread, 1, 5_000));
+
+    log("experiment 2: karate channel while the VM is suspended, which is what a java "
+      + "breakpoint with the default suspend policy does");
+    vm.suspend();
+    log("vm.suspend() returned; suspendCount on the paused scenario thread: "
+      + suspendCount(vm, thread));
+    long blocked = askVariables(thread, 2, 5_000);
+    report(blocked);
+
+    log("experiment 3: does a karate resume issued during the suspension survive it");
+    toAgent.println("RESUME " + thread);
+    String duringSuspension = fromAgent.poll(3, TimeUnit.SECONDS);
+    log("anything from the agent in 3s of suspension: " + duringSuspension);
+
+    long resumedAt = System.currentTimeMillis();
+    vm.resume();
+    String afterResume = fromAgent.poll(10, TimeUnit.SECONDS);
+    log("first line after vm.resume(), " + (System.currentTimeMillis() - resumedAt) + "ms later: "
+      + afterResume);
+
+    log("experiment 4: the java breakpoint in the user's own code");
+    if (hits.latch.await(30, TimeUnit.SECONDS)) {
+      log("java breakpoint hit on thread: " + hits.threadName
+        + " (virtual: " + hits.virtualThread + ")");
+      log("karate channel while stopped at the java breakpoint:");
+      report(askVariables(thread, 4, 5_000));
+      hits.release();
+      log("released the java breakpoint");
+    } else {
+      log("FAIL - the java breakpoint in sample.Helper never hit"
+        + (hits.armed ? "" : " (it was never armed - Helper was not prepared)"));
+    }
+  }
+
+  /** Sends a VARIABLES request and returns how long the reply took, or -1 if none came. */
+  private long askVariables(String thread, int id, long timeoutMillis) throws InterruptedException {
+    fromAgent.clear();
+    long start = System.currentTimeMillis();
+    toAgent.println("VARIABLES " + thread + " " + id);
+    String reply = fromAgent.poll(timeoutMillis, TimeUnit.MILLISECONDS);
+    return reply == null ? -1 : System.currentTimeMillis() - start;
+  }
+
+  private void report(long millis) {
+    log(millis < 0 ? "  -> no reply: the channel is frozen" : "  -> replied in " + millis + "ms");
+  }
+
+  private String awaitPaused(long timeoutMillis) throws InterruptedException {
+    long deadline = System.currentTimeMillis() + timeoutMillis;
+    while (System.currentTimeMillis() < deadline) {
+      String message = fromAgent.poll(deadline - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      if (message == null) {
+        return null;
+      }
+      if (message.startsWith("EVENT PAUSED ")) {
+        Matcher matcher = THREAD.matcher(message);
+        return matcher.find() ? matcher.group(1) : "";
+      }
+    }
+    return null;
+  }
+
+  // -------------------------------------------------------------- plumbing
+
+  private Process launchChild(int idePort, Path feature, int jdwpPort, String parallelism)
+    throws IOException {
+    List<String> command = List.of(
+      Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=127.0.0.1:" + jdwpPort,
+      "-cp", System.getProperty("java.class.path"),
+      JdwpClashProbe.class.getName(), "child", String.valueOf(idePort), feature.toString(),
+      parallelism);
+    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    Thread pump = new Thread(() -> pump(process.getInputStream()), "child-output");
+    pump.setDaemon(true);
+    pump.start();
+    return process;
+  }
+
+  private static void pump(InputStream stream) {
+    try (BufferedReader reader = new BufferedReader(
+      new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.startsWith("<<UPPERCUT-V2>> SUITE_EXIT") || line.startsWith("<<UPPERCUT-V2>> FEATURE_EXIT")) {
+          System.out.println("[child] " + line.substring(0, Math.min(120, line.length())) + " ...");
+        } else {
+          System.out.println("[child] " + line);
+        }
+      }
+    } catch (IOException e) {
+      // the child ended
+    }
+  }
+
+  private static VirtualMachine attach(int port) throws Exception {
+    AttachingConnector connector = Bootstrap.virtualMachineManager().attachingConnectors().stream()
+      .filter(c -> "com.sun.jdi.SocketAttach".equals(c.name()))
+      .findFirst().orElseThrow(() -> new IllegalStateException("no SocketAttach connector"));
+    Map<String, Connector.Argument> arguments = connector.defaultArguments();
+    arguments.get("hostname").setValue("127.0.0.1");
+    arguments.get("port").setValue(String.valueOf(port));
+    IllegalStateException last = new IllegalStateException("could not attach");
+    for (int attempt = 0; attempt < 40; attempt++) {
+      try {
+        return connector.attach(arguments);
+      } catch (IOException e) {
+        Thread.sleep(250);
+      }
+    }
+    throw last;
+  }
+
+  /** What the JDI event thread records about the breakpoint in sample.Helper. */
+  private static final class BreakpointHits {
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile boolean armed;
+    private volatile String threadName;
+    private volatile boolean virtualThread;
+    private volatile EventSet held;
+
+    private void release() {
+      EventSet set = held;
+      if (set != null) {
+        set.resume();
+      }
+    }
+  }
+
+  /**
+   * Arms a breakpoint on {@code Helper.compute} with the default suspend-all policy - the point of
+   * the probe is what the IDE's default does, not what a careful user could choose instead.
+   */
+  private void armHelperBreakpoint(VirtualMachine vm, BreakpointHits hits) {
+    ClassPrepareRequest prepare = vm.eventRequestManager().createClassPrepareRequest();
+    prepare.addClassFilter("sample.Helper");
+    prepare.setSuspendPolicy(EventRequest.SUSPEND_ALL);
+    prepare.enable();
+
+    Thread events = new Thread(() -> {
+      try {
+        while (true) {
+          EventSet set = vm.eventQueue().remove();
+          boolean hold = false;
+          for (Event event : set) {
+            if (event instanceof ClassPrepareEvent prepared) {
+              ReferenceType type = prepared.referenceType();
+              BreakpointRequest breakpoint = vm.eventRequestManager()
+                .createBreakpointRequest(type.methodsByName("compute").get(0).location());
+              breakpoint.setSuspendPolicy(EventRequest.SUSPEND_ALL);
+              breakpoint.enable();
+              hits.armed = true;
+              log("armed a java breakpoint on sample.Helper.compute, suspend policy ALL");
+            } else if (event instanceof BreakpointEvent stopped) {
+              ThreadReference thread = stopped.thread();
+              hits.threadName = thread.name() + " #" + thread.uniqueID();
+              hits.virtualThread = isVirtual(thread);
+              hits.held = set;
+              hits.latch.countDown();
+              hold = true;
+            } else if (event instanceof VMDeathEvent || event instanceof VMDisconnectEvent) {
+              return;
+            }
+          }
+          if (!hold) {
+            set.resume();
+          }
+        }
+      } catch (Exception e) {
+        log("jdi event loop ended: " + e);
+      }
+    }, "jdi-events");
+    events.setDaemon(true);
+    events.start();
+  }
+
+  private static boolean isVirtual(ThreadReference thread) {
+    try {
+      return (boolean) ThreadReference.class.getMethod("isVirtual").invoke(thread);
+    } catch (ReflectiveOperationException e) {
+      return thread.name().startsWith("VirtualThread");
+    }
+  }
+
+  private static String suspendCount(VirtualMachine vm, String threadKey) {
+    try {
+      return vm.allThreads().stream()
+        .filter(t -> threadKey.equals(t.name()))
+        .findFirst()
+        .map(t -> String.valueOf(t.suspendCount()))
+        .orElse("(thread " + threadKey + " not visible to JDI)");
+    } catch (Exception e) {
+      return "(" + e + ")";
+    }
+  }
+
+  /** The IDE's karate tab: one breakpoint on the step that calls Java, then relay everything. */
+  private void serveChannel(ServerSocket server, Path feature) {
+    try (Socket socket = server.accept();
+      BufferedReader in = new BufferedReader(
+        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+      PrintWriter out = new PrintWriter(socket.getOutputStream(), true)) {
+      toAgent = out;
+      out.println("PAUSE_ON_FAILURE false");
+      out.println("CLEAR");
+      out.println("BREAKPOINT " + base64(feature.toString()) + " " + JAVA_CALL_LINE);
+      out.println("BREAKPOINTS_END");
+      agentConnected.countDown();
+      String message;
+      while ((message = in.readLine()) != null) {
+        log("← " + (message.length() > 160 ? message.substring(0, 160) + " ..." : message));
+        fromAgent.put(message);
+      }
+    } catch (IOException | InterruptedException e) {
+      log("karate channel ended: " + e);
+    }
+  }
+
+  private static String base64(String value) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void log(String message) {
+    System.out.println("[JDWP-CLASH] " + message);
+  }
+}

--- a/testProjects/karate-versions/v2/src/test/java/sample/javacall.feature
+++ b/testProjects/karate-versions/v2/src/test/java/sample/javacall.feature
@@ -1,0 +1,8 @@
+Feature: java called from a feature - the case an opt-in JVM debugger would serve
+
+  Scenario: call into the user's own Java
+    * def seed = 20
+    * def Helper = Java.type('sample.Helper')
+    * def answer = Helper.compute(seed)
+    * print 'answer is', answer
+    * match answer == 41


### PR DESCRIPTION
Karate runs are debugged by the plugin itself with no JDWP, which leaves no way to stop in Java a feature calls through `Java.type(...)`, or to step into karate-core. Tick **Attach the JVM debugger too** on a run configuration and Debug opens a second tab — a stock Remote JVM Debug session on the same test JVM — where Java breakpoints stop as usual. Off by default: a Java breakpoint suspends every thread in the JVM, so the Karate tab stops answering until the Java tab resumes, and nothing is lost but it catches up rather than staying live.

`Karate2UITest` gains one test covering both the ticked and unticked cases. It is the first test in the suite to set a breakpoint, so gutter registration is now covered on a feature step and a Java line.

Change notes now come from a release's `### Highlights` section alone. The whole changelog was being broadcast to the Marketplace and the IDE's update popup.

Released as 3.2.0.

Design, and the spike that settled how two debuggers share one JVM: `docs/DEBUGGER.md`, phase 6.