### PR TITLE
Lex '||' in a table as two delimiters, not a logical OR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## [Unreleased]
 
+### Highlights
+
+- **Writing an `Examples:` table no longer freezes the IDE.** A row containing `||` sent the lexer
+  into a loop that pegged the CPU until the IDE was killed. (#380)
+
+### Fixed
+
+- Fixed the IDE freezing, with the CPU pegged, while writing an `Examples:` table. A row containing
+  `||` — an empty cell, and also what is on screen for a moment while typing a row out — made the
+  lexer produce a cell that ended before it began and then stop advancing, so the editor rebuilt a
+  broken token sequence on every keystroke. Any reparse of such a file could hang, not only typing
+  in one. (#380)
+
 ## [3.2.0] - 2026-09-07
 
 ### Highlights

--- a/src/main/java/com/rankweis/uppercut/karate/lexer/UppercutLexer.java
+++ b/src/main/java/com/rankweis/uppercut/karate/lexer/UppercutLexer.java
@@ -486,9 +486,10 @@ public class UppercutLexer extends LexerBase {
       myCurrentToken = TEXT;
       advanceToNextInterestingToken();
     } else if (c == '|' && myState != STATE_INSIDE_PYSTRING
-      && (myPosition + 1 >= myEndOffset || myBuffer.charAt(myPosition + 1) != '|')) {
+      && (myState == STATE_TABLE || myPosition + 1 >= myEndOffset || myBuffer.charAt(myPosition + 1) != '|')) {
       // Single '|' is a table pipe delimiter. '||' is a logical OR operator
-      // (e.g., in Karate's "* if (a || b)") and should be treated as TEXT.
+      // (e.g., in Karate's "* if (a || b)") and should be treated as TEXT - but only outside a
+      // table, where '||' is an empty cell between two delimiters.
       myCurrentToken = KarateTokenTypes.PIPE;
       myPosition++;
       myState = STATE_TABLE;
@@ -520,8 +521,14 @@ public class UppercutLexer extends LexerBase {
         }
         myPosition++;
       }
-      while (myPosition > 0 && Character.isWhitespace(myBuffer.charAt(myPosition - 1))) {
+      // Trailing whitespace belongs to the following WHITE_SPACE token, not to the cell. Stop at
+      // the token start: a cell that ends at or before where it began stalls the lexer, and the
+      // editor's incremental highlighter spins on the broken token sequence.
+      while (myPosition > myCurrentTokenStart && Character.isWhitespace(myBuffer.charAt(myPosition - 1))) {
         myPosition--;
+      }
+      if (myPosition == myCurrentTokenStart) {
+        myPosition++;
       }
     } else if (isStringAtPosition("function") && containsCharEarlierInLine('=') && jsLexer != null) {
       int endOfFunction = findNextMatchingClosingBrace();

--- a/src/test/java/com/rankweis/uppercut/karate/lexer/UppercutLexerTest.java
+++ b/src/test/java/com/rankweis/uppercut/karate/lexer/UppercutLexerTest.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.testFramework.ExtensionTestUtil;
 import com.intellij.testFramework.LightPlatformTestCase;
 import com.rankweis.uppercut.karate.psi.GherkinKeywordProvider;
+import com.rankweis.uppercut.karate.psi.KarateTokenTypes;
 import io.karatelabs.js.KarateJsNoPluginExtension;
 import java.util.List;
 import org.mockito.Mock;
@@ -92,6 +93,54 @@ public class UppercutLexerTest extends LightPlatformTestCase {
     lexer.start("", 0, 0, 0);
     lexer.advance();
     assertNull(lexer.getTokenType());
+  }
+
+  /**
+   * The editor's incremental highlighter requires a gapless token sequence in which every token
+   * advances. A cell that ends at or before it starts breaks that sequence and stalls the lexer -
+   * see https://github.com/rankweis/uppercut/issues/380, where typing an Examples table froze the IDE.
+   */
+  private void assertLexesCleanly(String text) {
+    lexer.start(text, 0, text.length(), 0);
+    int expectedStart = 0;
+    int guard = 0;
+    while (lexer.getTokenType() != null) {
+      final int start = lexer.getTokenStart();
+      final int end = lexer.getTokenEnd();
+      assertTrue("token " + lexer.getTokenType() + " ends at " + end + " but starts at " + start
+        + " in [" + text + "]", end > start);
+      assertEquals("gap or overlap before " + lexer.getTokenType() + " in [" + text + "]",
+        expectedStart, start);
+      expectedStart = end;
+      if (++guard > 5000) {
+        fail("lexer did not terminate on [" + text + "]");
+      }
+      lexer.advance();
+    }
+    assertEquals("tokens do not cover [" + text + "]", text.length(), expectedStart);
+  }
+
+  public void testEmptyTableCellDoesNotStallTheLexer() {
+    assertLexesCleanly("Examples:\n  |a||b|\n");
+  }
+
+  public void testDoublePipeAfterSpaceDoesNotStallTheLexer() {
+    assertLexesCleanly("Examples:\n  |dateOfBirth| ||\n");
+  }
+
+  public void testUnfinishedTableRowDoesNotStallTheLexer() {
+    assertLexesCleanly("Examples:\n  |dateOfBirth| ||+\n");
+  }
+
+  public void testLogicalOrOutsideTableIsNotDelimiter() {
+    String text = "* if (a || b) print 'x'\n";
+    assertLexesCleanly(text);
+    lexer.start(text, 0, text.length(), 0);
+    while (lexer.getTokenType() != null) {
+      assertNotSame("'||' outside a table must not lex as a table delimiter",
+        KarateTokenTypes.PIPE, lexer.getTokenType());
+      lexer.advance();
+    }
   }
 
   public void testContainsCharEarlierInLine() {


### PR DESCRIPTION
Typing an `Examples:` table froze the IDE with the CPU pegged, until it had to be killed.

**What was broken.** The pipe branch skips `|` when the next character is also `|`, so `* if (a || b)` does not lex as table delimiters. Inside a table that sent `||` to the `STATE_TABLE` branch, whose scan loop breaks immediately on `|` without advancing, and the trailing-whitespace trim that follows was bounded by `0` rather than by the token start — so it walked the token end back past the preceding space. The result is a `TABLE_CELL` whose end precedes its start and a lexer that makes no progress.

**How it surfaced.** The editor's incremental highlighter logs `Token sequence broken` and `Error calculating attributes` on every keystroke and re-lexes the file each time; a reparse hits the same spot through `PsiBuilderImpl`, so the hang is reachable without typing. `|a||b|` — an empty cell — stalls on its own; no trailing space needed.

**The fix.** Treat `|` as a delimiter whenever the lexer is already inside a table, where `||` is an empty cell. Bound the trim at the token start as `returnWhitespace()` does elsewhere, and never emit a cell that fails to advance, so a reordering cannot reintroduce the stall.

**Verified.** Reproduced in `runIde` against the reporter's file, then confirmed silent after the fix. Four regression tests in `UppercutLexerTest` cover the empty cell, `||` after a space, the unfinished row from the reporter's document, and `* if (a || b)` still not lexing as a table; the shared helper asserts the contract the incremental highlighter needs — gapless, covering, every token advancing. `./gradlew check -x integrationTest` passes.

Present since v2.4.14, where the `||` guard was introduced; not a 3.x regression.

Fixes #380