### PR TITLE
Never resume a lex from an injection state we cannot rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   lexer produce a cell that ended before it began and then stop advancing, so the editor rebuilt a
   broken token sequence on every keystroke. Any reparse of such a file could hang, not only typing
   in one. (#380)
+- Closed off two more ways the lexer could hang on a feature file, both neighbours of the same
+  fault: resuming a highlight part-way through an embedded JavaScript, JSON or XML block used to
+  read positions from whichever block was lexed last, and a Karate marker such as `#(response.id)`
+  or `#string` running past the end of an embedded JSON block could spin. Neither had been reported.
 
 ## [3.2.0] - 2026-09-07
 

--- a/src/main/java/com/rankweis/uppercut/karate/lexer/UppercutLexer.java
+++ b/src/main/java/com/rankweis/uppercut/karate/lexer/UppercutLexer.java
@@ -18,7 +18,6 @@ import static com.rankweis.uppercut.karate.psi.KarateTokenTypes.VARIABLE;
 import com.intellij.json.json5.Json5Lexer;
 import com.intellij.lexer.Lexer;
 import com.intellij.lexer.LexerBase;
-import com.intellij.lexer.LexerPosition;
 import com.intellij.lexer.XmlLexer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.util.text.Strings;
@@ -191,6 +190,16 @@ public class UppercutLexer extends LexerBase {
     myEndOffset = endOffset;
     myPosition = startOffset;
     myState = initialState;
+
+    // An injection state only means something alongside the sub-lexer that produced it, and a
+    // sub-lexer cannot be rebuilt from the state alone - its region bounds are not in there. Left
+    // as-is, advance() would read offsets off whichever region the sub-lexer was last started on
+    // and hand back a token ending before it began, which stalls the lexer and breaks the editor's
+    // token sequence. Re-lex from here as Karate instead: the colours inside the injection are
+    // wrong until the next full pass, which beats a hang.
+    if (injectingJson() || injectingJavascript() || injectingXml()) {
+      myState = STATE_DEFAULT;
+    }
 
     // setup context — count pystring markers before start position to detect
     // if we're resuming inside an unclosed pystring
@@ -857,24 +866,6 @@ public class UppercutLexer extends LexerBase {
     myPosition = xmlLexer.getTokenEnd();
   }
 
-  @Override
-  public void restore(@NotNull LexerPosition position) {
-    super.restore(position);
-    if (injecting()) {
-      int endPos = myPosition;
-      while (endPos < myEndOffset && !isStringAtPosition(PYSTRING_MARKER, endPos)) {
-        endPos++;
-      }
-      endPos = Math.min(endPos, myEndOffset);
-      if (injectingJson()) {
-        jsonLexer.start(myBuffer, myStartOffset, endPos, jsonLexer.getState() - INJECTING_JSON);
-      } else if (injectingJavascript()) {
-        jsLexer.start(myBuffer, myStartOffset, endPos, jsLexer.getState() - INJECTING_JAVASCRIPT);
-      } else if (injectingXml()) {
-        xmlLexer.start(myBuffer, myStartOffset, endPos, xmlLexer.getState() - INJECTING_XML);
-      }
-    }
-  }
 
   /**
    * Advances one token within a JSON injection region. Before delegating to the JSON sub-lexer,
@@ -901,7 +892,7 @@ public class UppercutLexer extends LexerBase {
         myBuffer.subSequence(myPosition, closingBrace).toString().trim()).matches()) {
         myCurrentToken = JSON_INJECTABLE;
         myPosition = closingBrace;
-        while (jsonLexer.getTokenEnd() < closingBrace) {
+        while (jsonLexer.getTokenType() != null && jsonLexer.getTokenEnd() < closingBrace) {
           jsonLexer.advance();
         }
         return;
@@ -916,7 +907,7 @@ public class UppercutLexer extends LexerBase {
         myBuffer.subSequence(myPosition, closingBrace).toString().trim()).matches()) {
         myCurrentToken = JSON_INJECTABLE;
         myPosition = closingBrace;
-        while (jsonLexer.getTokenEnd() < closingBrace) {
+        while (jsonLexer.getTokenType() != null && jsonLexer.getTokenEnd() < closingBrace) {
           jsonLexer.advance();
         }
         return;
@@ -935,7 +926,7 @@ public class UppercutLexer extends LexerBase {
       if (injectable > 0) {
         myCurrentToken = JSON_INJECTABLE;
         myPosition += injectable;
-        while (jsonLexer.getTokenEnd() < myPosition) {
+        while (jsonLexer.getTokenType() != null && jsonLexer.getTokenEnd() < myPosition) {
           jsonLexer.advance();
         }
         return;

--- a/src/test/java/com/rankweis/uppercut/karate/lexer/UppercutLexerTest.java
+++ b/src/test/java/com/rankweis/uppercut/karate/lexer/UppercutLexerTest.java
@@ -6,6 +6,7 @@ import com.intellij.testFramework.LightPlatformTestCase;
 import com.rankweis.uppercut.karate.psi.GherkinKeywordProvider;
 import com.rankweis.uppercut.karate.psi.KarateTokenTypes;
 import io.karatelabs.js.KarateJsNoPluginExtension;
+import java.util.ArrayList;
 import java.util.List;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -140,6 +141,54 @@ public class UppercutLexerTest extends LightPlatformTestCase {
       assertNotSame("'||' outside a table must not lex as a table delimiter",
         KarateTokenTypes.PIPE, lexer.getTokenType());
       lexer.advance();
+    }
+  }
+
+  /**
+   * A state carrying a sub-lexer's offset means nothing without that sub-lexer, which start() has
+   * no way to rebuild. Restarting from one used to read offsets off whichever region the sub-lexer
+   * was last pointed at; the lexer must fall back to plain Karate rather than emit a token that
+   * ends before it began.
+   */
+  public void testRestartFromEveryTokenBoundaryStaysValid() {
+    String text = """
+      Feature: f
+
+        Background:
+          * def now = function() { return java.lang.System.currentTimeMillis() }
+          * def body = { "id": "#(response.id)", "kind": "#string" }
+
+        Scenario Outline: s
+          Examples:
+            |a|b|
+      """;
+    List<Integer> states = new ArrayList<>();
+    List<Integer> starts = new ArrayList<>();
+    lexer.start(text, 0, text.length(), 0);
+    while (lexer.getTokenType() != null) {
+      starts.add(lexer.getTokenStart());
+      states.add(lexer.getState());
+      lexer.advance();
+    }
+    // the state recorded on token i is what a restart at token i+1 would replay
+    for (int i = 0; i < starts.size() - 1; i++) {
+      lexer.start(text, starts.get(i + 1), text.length(), states.get(i));
+      int expectedStart = starts.get(i + 1);
+      int guard = 0;
+      while (lexer.getTokenType() != null) {
+        assertEquals("gap or overlap restarting at " + starts.get(i + 1) + " in state " + states.get(i),
+          expectedStart, lexer.getTokenStart());
+        assertTrue("token " + lexer.getTokenType() + " ends at " + lexer.getTokenEnd()
+          + " but starts at " + lexer.getTokenStart() + ", restarting at " + starts.get(i + 1)
+          + " in state " + states.get(i), lexer.getTokenEnd() > lexer.getTokenStart());
+        expectedStart = lexer.getTokenEnd();
+        if (++guard > 5000) {
+          fail("lexer did not terminate restarting at " + starts.get(i + 1) + " in state " + states.get(i));
+        }
+        lexer.advance();
+      }
+      assertEquals("tokens do not reach the end restarting at " + starts.get(i + 1),
+        text.length(), expectedStart);
     }
   }
 


### PR DESCRIPTION
Follow-up to #381. Three fixes of the same shape as the `||` table freeze: the lexer hands back positions it has no basis for, then stops advancing.

**`start()` cannot rebuild a sub-lexer from a state number.** An injection state is `1000`/`2000`/`3000` plus the sub-lexer's own state, but the region bounds are not in that number. `start()` assigned it to `myState` anyway, so `advance()` read `getBufferEnd()`/`getTokenEnd()` off whichever region the sub-lexer was last started on. Restarting at every token boundary of a file with one JS block and one JSON block produced a stream that never reached the end of the buffer. Now falls back to `STATE_DEFAULT` — colours inside the injection are wrong until the next full pass, which beats a hang.

**`restore()` tried to repair that and made it worse.** It computed the sub-lexer's initial state as `jsLexer.getState() - INJECTING_JAVASCRIPT`, subtracting the bucket offset from the sub-lexer's own small state rather than from `myState`, handing a large negative state to a `FlexAdapter`; and it restarted the sub-lexer at `myStartOffset` rather than at the injection region. Nothing calls it, and with `start()` guarding itself `LexerBase.restore()` is now correct — so the override is dropped rather than fixed.

**The three resync loops in `injectJson()` were unbounded.** They advance the JSON sub-lexer to a target derived from `myEndOffset`, which bounds the whole buffer rather than the injected region. A `#(…)` or `#keyword` marker straddling the region end leaves the target beyond it, and an exhausted lexer reports a constant token end. Now stops when the sub-lexer runs out.

**Confidence.** The first is demonstrated: `testRestartFromEveryTokenBoundaryStaysValid` fails without the `start()` guard (`tokens do not reach the end restarting at 50 expected:<213> but was:<50>`). The second is a plain arithmetic error on a code path I could not find a caller for. The third I could not construct an input for — `BARE_INJECTABLE` is `#\(\S+\)`, so the marker admits no whitespace, which limits how far past the region end the target can land — so it is insurance against a class of fault we just got bitten by, not a known defect.

`./gradlew check -x integrationTest` passes.