### PR TITLE
Quieten the embedded JavaScript parser, and pin which engine runs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped filling `idea.log` with stack traces while you type. Every keystroke that left a step's
+  embedded JavaScript half-written logged a parse failure at warning level, stack trace and all —
+  and half-written is what JavaScript looks like for as long as you are writing it. The mistake is
+  still marked in the editor where it belongs; only the logging is gone.
+
 ## [3.2.1] - 2026-09-09
 
 ### Highlights

--- a/src/main/java/com/rankweis/uppercut/karate/lexer/UppercutLexer.java
+++ b/src/main/java/com/rankweis/uppercut/karate/lexer/UppercutLexer.java
@@ -81,7 +81,6 @@ import org.jetbrains.annotations.VisibleForTesting;
 public class UppercutLexer extends LexerBase {
 
   protected CharSequence myBuffer = Strings.EMPTY_CHAR_SEQUENCE;
-  protected int myStartOffset = 0;
   protected int myEndOffset = 0;
   private int myPosition;
   private IElementType myCurrentToken;
@@ -186,7 +185,6 @@ public class UppercutLexer extends LexerBase {
 
   public void start(@NotNull CharSequence buffer, int startOffset, int endOffset, int initialState, boolean advance) {
     myBuffer = buffer;
-    myStartOffset = startOffset;
     myEndOffset = endOffset;
     myPosition = startOffset;
     myState = initialState;

--- a/src/main/java/io/karatelabs/js/KarateJsParser.java
+++ b/src/main/java/io/karatelabs/js/KarateJsParser.java
@@ -53,7 +53,10 @@ public class KarateJsParser implements PsiParser {
     try {
       new Parser(new Source(sb.toString()), b, currentOffset).parse();
     } catch (Exception e) {
-      logger.warn("Error parsing", e);
+      // Half-written JavaScript is the normal state of a file being typed in, and the error is
+      // already reported where it belongs - as an error element on the offending token, below.
+      // At warn this logged a stack trace to stdout on every keystroke.
+      logger.debug("Error parsing embedded JavaScript", e);
       int errorOffset = b.getCurrentOffset();
       markRoot.rollbackTo();
       PsiBuilder.Marker error = b.mark();

--- a/src/test/java/com/rankweis/uppercut/karate/lexer/KarateJsEngineSelectionTest.java
+++ b/src/test/java/com/rankweis/uppercut/karate/lexer/KarateJsEngineSelectionTest.java
@@ -1,0 +1,77 @@
+package com.rankweis.uppercut.karate.lexer;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.testFramework.ExtensionTestUtil;
+import com.intellij.testFramework.LightPlatformTestCase;
+import com.rankweis.uppercut.karate.lexer.impl.KarateJavascriptExtension;
+import com.rankweis.uppercut.karate.psi.PlainKarateKeywordProvider;
+import com.rankweis.uppercut.settings.KarateSettingsState;
+import io.karatelabs.js.KarateJsNoPluginExtension;
+import java.util.List;
+
+/**
+ * Which JavaScript engine lexes an embedded block is decided by position in the extension list:
+ * plugin.xml registers the bundled karate-js engine {@code order="last"} and plugin-withJs.xml
+ * registers the IntelliJ JavaScript plugin {@code order="first"}, so callers take the last element
+ * for the bundled engine and the first for the JS plugin. Nothing in the code says which end is
+ * which, and the two halves live in different files, so a reordering would silently swap engines.
+ *
+ * <p>This pins the selection given that order. It cannot pin the {@code order=} attributes
+ * themselves - the extensions are masked here rather than loaded from the descriptors.
+ */
+public class KarateJsEngineSelectionTest extends LightPlatformTestCase {
+
+  private static final String STEP = "* def now = function() { return 1 }\n";
+
+  private boolean originalSetting;
+
+  @Override public void setUp() throws Exception {
+    super.setUp();
+    if (!ApplicationManager.getApplication().getExtensionArea()
+        .hasExtensionPoint(KarateJavascriptParsingExtensionPoint.EP_NAME.getName())) {
+      ApplicationManager.getApplication().getExtensionArea().registerExtensionPoint(
+        KarateJavascriptParsingExtensionPoint.EP_NAME.getName(),
+        KarateJavascriptParsingExtensionPoint.class.getName(),
+        com.intellij.openapi.extensions.ExtensionPoint.Kind.INTERFACE, false);
+    }
+    // the order the two descriptors produce when the JavaScript plugin is present
+    ExtensionTestUtil.maskExtensions(KarateJavascriptParsingExtensionPoint.EP_NAME,
+      List.of(new KarateJavascriptExtension(), new KarateJsNoPluginExtension()), getTestRootDisposable());
+    originalSetting = KarateSettingsState.getInstance().isUseKarateJavaScriptEngine();
+  }
+
+  @Override public void tearDown() throws Exception {
+    try {
+      KarateSettingsState.getInstance().setUseKarateJavaScriptEngine(originalSetting);
+    } finally {
+      super.tearDown();
+    }
+  }
+
+  /** Token name for the {@code function} keyword, which differs between the two engines. */
+  private String functionTokenName() {
+    UppercutLexer lexer = new UppercutLexer(new PlainKarateKeywordProvider());
+    lexer.start(STEP, 0, STEP.length(), 0);
+    while (lexer.getTokenType() != null) {
+      final IElementType type = lexer.getTokenType();
+      if ("function".contentEquals(STEP.subSequence(lexer.getTokenStart(), lexer.getTokenEnd()))) {
+        return String.valueOf(type);
+      }
+      lexer.advance();
+    }
+    throw new AssertionError("no token covered the 'function' keyword");
+  }
+
+  public void testDefaultPrefersJavaScriptPlugin() {
+    KarateSettingsState.getInstance().setUseKarateJavaScriptEngine(false);
+    assertEquals("with the setting off the IntelliJ JavaScript plugin should lex the block",
+      "JS:FUNCTION_KEYWORD", functionTokenName());
+  }
+
+  public void testSettingSelectsBundledEngine() {
+    KarateSettingsState.getInstance().setUseKarateJavaScriptEngine(true);
+    assertEquals("with the setting on the bundled karate-js engine should lex the block",
+      "FUNCTION", functionTokenName());
+  }
+}


### PR DESCRIPTION
Three small things, rebased onto 3.2.2.

### Stop logging a stack trace for every half-typed JavaScript expression

`KarateJsParser` logged its parse failure at `warn` with the exception attached, which slf4j sends to stdout and IDEA captures into `idea.log`. Embedded JavaScript is unparseable for as long as someone is writing it, so this fired on most keystrokes in a step with a function body.

The failure is already reported where a user can act on it — the catch block marks the offending token with `Invalid javaScript - <message>`. The log line only duplicated that, so it drops to `debug`. Nothing about error recovery changes.

### Remove a dead field

`UppercutLexer.myStartOffset` lost its only reader when `restore()` was deleted in #382; it is now written and never read. Nothing extends `UppercutLexer`. `LegacyUppercutLexer` keeps its own copy — it is a frozen snapshot for the benchmark, not a subclass.

### Pin which JavaScript engine lexes an embedded block

Test only. Which engine runs is decided by position in the extension list: `plugin.xml` registers the bundled karate-js engine `order="last"`, `plugin-withJs.xml` registers the IntelliJ JavaScript plugin `order="first"`, and callers take `getLast()` for the bundled engine and `getFirst()` for the JS plugin. Nothing in the code says which end is which, the two halves live in different descriptors, and four call sites repeat the pairing (`UppercutLexer`, `UppercutSyntaxHighlighter`, `UppercutParser`, `GherkinBlock`) — a reordering would swap engines silently.

The test asserts it through the token the lexer emits for `function`, which the two engines name differently (`JS:FUNCTION_KEYWORD` vs `FUNCTION`). Inverting the condition in the `UppercutLexer` constructor fails both cases, so it catches the mistake it is aimed at.

**What it does not cover:** the `order=` attributes themselves. The extensions are masked in the test rather than loaded from the descriptors, so it pins the selection *given* that order, not the order.

**Why it exists.** While verifying #382 in a sandbox IDE, the bundled engine was logging parse errors and it looked like `plugin-withJs.xml` was failing to resolve. It wasn't — that sandbox had `useKarateJavaScriptEngine` turned on in its persisted config, so `getLast()` was correct. The pairing is subtle enough that it read as a bug.

`./gradlew check -x integrationTest` passes.